### PR TITLE
Add -all-script-data flag in remove command to remove all script cache data

### DIFF
--- a/Sources/MarathonCore/Command.swift
+++ b/Sources/MarathonCore/Command.swift
@@ -74,7 +74,7 @@ extension Command {
         case .edit:
             return "<path-to-script> [-no-xcode] [-no-open]"
         case .remove:
-            return "<name-of-package-or-path-to-script>"
+            return "<name-of-package-or-path-to-script> [-all-script-data]"
         case .run:
             return "<path-to-script> [<script-arguments...>]"
         case .add:

--- a/Sources/MarathonCore/Help.swift
+++ b/Sources/MarathonCore/Help.swift
@@ -55,7 +55,8 @@ internal final class HelpTask: Task, Executable {
                    "To open the source file directly (without an Xcode project), pass the '-no-xcode' flag\n" +
                    "To not open the script at all, pass the 'no-open' flag"
         case .remove:
-            return "You can use this command to clean up data for scripts or packages no longer needed. To list them, use 'marathon list'"
+            return "You can use this command to clean up data for scripts or packages no longer needed. To list them, use 'marathon list'\n" +
+                   "To remove all packages, pass the '-all-script-data' flag"
         case .run:
             return "The script will be compiled and run, and any output generated will be returned"
         case .add:

--- a/Sources/MarathonCore/Remove.swift
+++ b/Sources/MarathonCore/Remove.swift
@@ -36,6 +36,11 @@ internal final class RemoveTask: Task, Executable {
     private typealias Error = RemoveError
 
     func execute() throws -> String {
+        if arguments.contains("-all-script-data") {
+            try scriptManager.removeAllScriptData()
+            return "🗑  Removed all script data"
+        }
+
         guard let identifier = arguments.first else {
             throw Error.missingIdentifier
         }

--- a/Sources/MarathonCore/ScriptManager.swift
+++ b/Sources/MarathonCore/ScriptManager.swift
@@ -88,6 +88,12 @@ internal final class ScriptManager {
         try perform(folder.delete(), orThrow: Error.failedToRemoveScriptFolder(folder))
     }
 
+    func removeAllScriptData() throws {
+        for path in managedScriptPaths {
+            try removeDataForScript(at: path)
+        }
+    }
+
     // MARK: - Private
 
     private func scriptIdentifier(from path: String) -> String {

--- a/Tests/MarathonTests/MarathonTests.swift
+++ b/Tests/MarathonTests/MarathonTests.swift
@@ -277,6 +277,28 @@ class MarathonTests: XCTestCase {
         XCTAssertEqual(scriptsFolder.subfolders.count, 0)
     }
 
+    func testRemovingAllScriptData() throws {
+        var scriptFiles: [File] = []
+
+        for i in 0..<3 {
+            let scriptFile = try folder.createFile(named: "script_\(i).swift")
+            try scriptFile.write(string: "import Foundation")
+            try run(with: ["run", scriptFile.path])
+            scriptFiles.append(scriptFile)
+        }
+
+        let scriptsFolder = try folder.subfolder(named: "Scripts")
+        XCTAssertEqual(scriptsFolder.subfolders.count, scriptFiles.count)
+
+        // Delete the script before running 'remove'
+        for scriptFile in scriptFiles {
+            try scriptFile.delete()
+        }
+
+        try run(with: ["remove", "-all-script-data"])
+        XCTAssertEqual(scriptsFolder.subfolders.count, 0)
+    }
+
     // MARK: - Updating packages
 
     func testUpdatingPackages() throws {


### PR DESCRIPTION
Added `-all-script-data` flag based on [this issue](https://github.com/JohnSundell/Marathon/issues/2).
I decided to use your suggested execution:)