### PR TITLE
Improve prefix of option commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ $ marathon edit helloWorld
 
 ...or in your favorite text editor
 ```
-$ marathon edit helloWorld -no-xcode
+$ marathon edit helloWorld --no-xcode
 ```
 
 👪 Share your scripts with your team and automatically install their dependencies:

--- a/Sources/MarathonCore/Command.swift
+++ b/Sources/MarathonCore/Command.swift
@@ -70,11 +70,11 @@ extension Command {
     var usageText: String {
         switch self {
         case .create:
-            return "<script-path> [<script-content>] [-no-xcode] [-no-open]"
+            return "<script-path> [<script-content>] [--no-xcode] [--no-open]"
         case .edit:
-            return "<path-to-script> [-no-xcode] [-no-open]"
+            return "<path-to-script> [--no-xcode] [--no-open]"
         case .remove:
-            return "<name-of-package-or-path-to-script> [-all-script-data]"
+            return "<name-of-package-or-path-to-script> [--all-script-data]"
         case .run:
             return "<path-to-script> [<script-arguments...>]"
         case .add:

--- a/Sources/MarathonCore/Help.swift
+++ b/Sources/MarathonCore/Help.swift
@@ -52,11 +52,11 @@ internal final class HelpTask: Task, Executable {
         switch command {
         case .create, .edit:
             return "The script will be opened for editing in Xcode by default\n" +
-                   "To open the source file directly (without an Xcode project), pass the '-no-xcode' flag\n" +
-                   "To not open the script at all, pass the '-no-open' flag"
+                   "To open the source file directly (without an Xcode project), pass the '--no-xcode' flag\n" +
+                   "To not open the script at all, pass the '--no-open' flag"
         case .remove:
             return "You can use this command to clean up data for scripts or packages no longer needed. To list them, use 'marathon list'\n" +
-                   "To remove all packages, pass the '-all-script-data' flag"
+                   "To remove all packages, pass the '--all-script-data' flag"
         case .run:
             return "The script will be compiled and run, and any output generated will be returned"
         case .add:

--- a/Sources/MarathonCore/Remove.swift
+++ b/Sources/MarathonCore/Remove.swift
@@ -36,7 +36,7 @@ internal final class RemoveTask: Task, Executable {
     private typealias Error = RemoveError
 
     func execute() throws -> String {
-        if arguments.contains("-all-script-data") {
+        if arguments.contains("--all-script-data") {
             try scriptManager.removeAllScriptData()
             return "🗑  Removed all script data"
         }

--- a/Sources/MarathonCore/Script.swift
+++ b/Sources/MarathonCore/Script.swift
@@ -88,7 +88,7 @@ internal final class Script {
     // MARK: - Private
 
     private func editingPath(from arguments: [String]) throws -> String {
-        guard !arguments.contains("-no-xcode") else {
+        guard !arguments.contains("--no-xcode") else {
             return try expandSymlink()
         }
 

--- a/Sources/MarathonCore/Task.swift
+++ b/Sources/MarathonCore/Task.swift
@@ -35,6 +35,6 @@ extension Task {
     }
 
     var argumentsContainNoOpenFlag: Bool {
-        return arguments.contains("-no-open")
+        return arguments.contains("--no-open")
     }
 }

--- a/Tests/MarathonTests/MarathonTests.swift
+++ b/Tests/MarathonTests/MarathonTests.swift
@@ -225,7 +225,7 @@ class MarathonTests: XCTestCase {
     }
 
     func testCreatingScriptWithName() throws {
-        try run(with: ["create", "script", "-no-open"])
+        try run(with: ["create", "script", "--no-open"])
 
         let scriptFile = try File(path: FileSystem().currentFolder.path + "script.swift")
 
@@ -237,7 +237,7 @@ class MarathonTests: XCTestCase {
         let scriptFolder = try folder.createSubfolder(named: "testScript")
         let scriptPath = scriptFolder.path + "script.swift"
 
-        try run(with: ["create", scriptPath, "-no-open"])
+        try run(with: ["create", scriptPath, "--no-open"])
         try XCTAssertFalse(scriptFolder.file(named: "script.swift").read().isEmpty)
     }
 
@@ -252,7 +252,7 @@ class MarathonTests: XCTestCase {
         let scriptFile = try folder.createFile(named: "script.swift")
         try scriptFile.write(string: script)
 
-        try run(with: ["edit", scriptFile.path, "-no-open"])
+        try run(with: ["edit", scriptFile.path, "--no-open"])
 
         let scriptFolders = try folder.subfolder(named: "Scripts").subfolders
         XCTAssertEqual(scriptFolders.count, 1)
@@ -264,7 +264,7 @@ class MarathonTests: XCTestCase {
         let scriptFile = try folder.createFile(named: "script.swift")
         try scriptFile.write(string: script)
 
-        try run(with: ["edit", scriptFile.path, "-no-xcode", "-no-open"])
+        try run(with: ["edit", scriptFile.path, "--no-xcode", "--no-open"])
 
         let scriptFolders = try folder.subfolder(named: "Scripts").subfolders
         XCTAssertEqual(scriptFolders.count, 1)
@@ -324,7 +324,7 @@ class MarathonTests: XCTestCase {
             try scriptFile.delete()
         }
 
-        try run(with: ["remove", "-all-script-data"])
+        try run(with: ["remove", "--all-script-data"])
         XCTAssertEqual(scriptsFolder.subfolders.count, 0)
     }
 


### PR DESCRIPTION
Replaced `-` with `--` as I mentioned in #12. I referred to [Carthage](https://github.com/Carthage/Carthage). In my opinion, `-` is better for a shortcut command option:)
I hope you like it.