### PR TITLE
Give suggestion to add a package if there is no such module

### DIFF
--- a/Sources/MarathonCore/Add.swift
+++ b/Sources/MarathonCore/Add.swift
@@ -23,14 +23,14 @@ extension AddError: PrintableError {
         }
     }
 
-    public var hint: String? {
+    public var hints: [String] {
         switch self {
         case .missingIdentifier:
-            return "When using 'add', pass either:\n" +
+            return ["When using 'add', pass either:\n" +
                    "- The git URL of a remote package to add (for example 'marathon add git@github.com:JohnSundell/Files.git')\n" +
-                   "- The path of a local package to add (for example 'marathon add packages/myPackage')"
+                   "- The path of a local package to add (for example 'marathon add packages/myPackage')"]
         case .invalidURL(_):
-            return nil
+            return []
         }
     }
 }

--- a/Sources/MarathonCore/Command.swift
+++ b/Sources/MarathonCore/Command.swift
@@ -21,8 +21,8 @@ public extension CommandError {
         }
     }
 
-    var hint: String? {
-        return "Type 'marathon help' for available commands"
+    var hints: [String] {
+        return ["Type 'marathon help' for available commands"]
     }
 }
 

--- a/Sources/MarathonCore/Create.swift
+++ b/Sources/MarathonCore/Create.swift
@@ -24,12 +24,12 @@ extension CreateError: PrintableError {
         }
     }
 
-    public var hint: String? {
+    public var hints: [String] {
         switch self {
         case .missingName:
-            return "Pass the name of a script file to create (for example 'marathon create myScript')"
+            return ["Pass the name of a script file to create (for example 'marathon create myScript')"]
         case .failedToCreateFile:
-            return "Make sure you have write permissions to the current folder"
+            return ["Make sure you have write permissions to the current folder"]
         }
     }
 }

--- a/Sources/MarathonCore/Edit.swift
+++ b/Sources/MarathonCore/Edit.swift
@@ -20,10 +20,10 @@ extension EditError: PrintableError {
         }
     }
 
-    public var hint: String? {
+    public var hints: [String] {
         switch self {
         case .missingPath:
-            return "Pass the name/path of a script file to edit (for example 'marathon edit myScript')"
+            return ["Pass the name/path of a script file to edit (for example 'marathon edit myScript')"]
         }
     }
 }

--- a/Sources/MarathonCore/Install.swift
+++ b/Sources/MarathonCore/Install.swift
@@ -20,10 +20,10 @@ extension InstallError: PrintableError {
         }
     }
 
-    public var hint: String? {
+    public var hints: [String] {
         switch self {
         case .missingPath:
-            return "Pass the path to a script file to install (for example 'marathon install script.swift')"
+            return ["Pass the path to a script file to install (for example 'marathon install script.swift')"]
         }
     }
 }

--- a/Sources/MarathonCore/PackageManager.swift
+++ b/Sources/MarathonCore/PackageManager.swift
@@ -47,7 +47,7 @@ extension PackageManagerError: PrintableError {
         }
     }
 
-    public var hint: String? {
+    public var hints: [String] {
         switch self {
         case .failedToResolveLatestVersion(let url):
             var hint = "Make sure that the package you're trying to add is reachable, and has at least one tagged release"
@@ -56,25 +56,25 @@ extension PackageManagerError: PrintableError {
                 hint += "\nYou can make a release by using 'git tag <version>' in your package's repository"
             }
 
-            return hint
+            return [hint]
         case .failedToResolveName(_):
-            return "Make sure that the package you're trying to add is reachable, and has a Package.swift file"
+            return ["Make sure that the package you're trying to add is reachable, and has a Package.swift file"]
         case .packageAlreadyAdded(let name):
-            return "Did you mean to update it? If so, run 'marathon update'\n" +
-                   "You can also remove the existing package using 'marathon remove \(name)', and then run 'add' again"
+            return ["Did you mean to update it? If so, run 'marathon update'\n" +
+                   "You can also remove the existing package using 'marathon remove \(name)', and then run 'add' again"]
         case .failedToSavePackageFile(_, let folder):
-            return "Make sure you have write permissions to the folder '\(folder.path)'"
+            return ["Make sure you have write permissions to the folder '\(folder.path)'"]
         case .failedToReadPackageFile(let name):
-            return "The file may have become corrupted. Try removing the package using 'marathon remove \(name)' and then add it back again"
+            return ["The file may have become corrupted. Try removing the package using 'marathon remove \(name)' and then add it back again"]
         case .failedToUpdatePackages(let folder):
-            return "Make sure you have write permissions to the folder '\(folder.path)'"
+            return ["Make sure you have write permissions to the folder '\(folder.path)'"]
         case .unknownPackageForRemoval(_):
-            return "Did you mean to remove the cache data for a script? If so, add '.swift' to its path\n" +
-                   "To list all added packages run 'marathon list'"
+            return ["Did you mean to remove the cache data for a script? If so, add '.swift' to its path\n" +
+                   "To list all added packages run 'marathon list'"]
         case .failedToRemovePackage(_, let folder):
-            return "Make sure you have write permissions to the folder '\(folder.path)'"
+            return ["Make sure you have write permissions to the folder '\(folder.path)'"]
         case .failedToReadMarathonFile(_):
-            return "Ensure that the file is formatted according to the documentation at https://github.com/johnsundell/marathon"
+            return ["Ensure that the file is formatted according to the documentation at https://github.com/johnsundell/marathon"]
         }
     }
 }

--- a/Sources/MarathonCore/PrintableError.swift
+++ b/Sources/MarathonCore/PrintableError.swift
@@ -9,6 +9,7 @@ import Foundation
 public protocol PrintableError: Error, Equatable, CustomStringConvertible {
     var message: String { get }
     var hint: String? { get }
+    var nextAction: String? { get }
 }
 
 public extension PrintableError {
@@ -16,11 +17,17 @@ public extension PrintableError {
         return lhs.message == rhs.message && lhs.hint == rhs.hint
     }
 
+    var nextAction: String? { return nil }
+
     var description: String {
         var description = "💥  \(message)"
 
         if let hint = hint {
             description.append("\n" + hint.withIndentedNewLines(prefix: "👉  "))
+        }
+
+        if let nextAction = nextAction {
+            description.append("\n" + nextAction.withIndentedNewLines(prefix: "👉  "))
         }
 
         return description

--- a/Sources/MarathonCore/PrintableError.swift
+++ b/Sources/MarathonCore/PrintableError.swift
@@ -8,26 +8,19 @@ import Foundation
 
 public protocol PrintableError: Error, Equatable, CustomStringConvertible {
     var message: String { get }
-    var hint: String? { get }
-    var nextAction: String? { get }
+    var hints: [String] { get }
 }
 
 public extension PrintableError {
     static func ==(lhs: Self, rhs: Self) -> Bool {
-        return lhs.message == rhs.message && lhs.hint == rhs.hint
+        return lhs.message == rhs.message && lhs.hints == rhs.hints
     }
-
-    var nextAction: String? { return nil }
 
     var description: String {
         var description = "💥  \(message)"
 
-        if let hint = hint {
-            description.append("\n" + hint.withIndentedNewLines(prefix: "👉  "))
-        }
-
-        if let nextAction = nextAction {
-            description.append("\n" + nextAction.withIndentedNewLines(prefix: "👉  "))
+        if !hints.isEmpty {
+            hints.forEach { description.append("\n" + $0.withIndentedNewLines(prefix: "👉  ")) }
         }
 
         return description

--- a/Sources/MarathonCore/Remove.swift
+++ b/Sources/MarathonCore/Remove.swift
@@ -20,12 +20,12 @@ extension RemoveError: PrintableError {
         }
     }
 
-    public var hint: String? {
+    public var hints: [String] {
         switch self {
         case .missingIdentifier:
-            return "When using 'remove', pass either:\n" +
+            return ["When using 'remove', pass either:\n" +
                    "- The name of a package to remove\n" +
-                   "- The path to a script to remove cache data for (including '.swift')"
+                   "- The path to a script to remove cache data for (including '.swift')"]
         }
     }
 }

--- a/Sources/MarathonCore/Run.swift
+++ b/Sources/MarathonCore/Run.swift
@@ -11,6 +11,7 @@ import Files
 
 public enum RunError {
     case missingPath
+    case failedToCompileScript([String], String?)
     case failedToRunScript(String)
 }
 
@@ -28,8 +29,27 @@ extension RunError: PrintableError {
         switch self {
         case .missingPath:
             return "Pass the path to a script file to run (for example 'marathon run script.swift')"
+        case .failedToCompileScript(let errors, _):
+            guard !errors.isEmpty else {
+                return nil
+            }
+
+            let separator = "\n- "
+            return "The following error(s) occured:" + separator + errors.joined(separator: separator)
         case .failedToRunScript(let message):
             return message
+        }
+    }
+
+    public var nextAction: String? {
+        switch self {
+        case .failedToCompileScript(_, let missingModule):
+            if let missingModule = missingModule {
+                return "You can add \(missingModule) to Marathon using 'marathon add <url-to-\(missingModule)>'"
+            }
+            return nil
+        default:
+            return nil
         }
     }
 }
@@ -54,5 +74,31 @@ internal class RunTask: Task, Executable {
         } catch {
             throw Error.failedToRunScript((error as! Process.Error).message)
         }
+    }
+
+    // MARK: - Private
+
+    private func formatCompileError(_ error: Process.Error, for script: Script) -> Error {
+        var messages = [String]()
+        var missingModule: String?
+
+        for outputComponent in error.output.components(separatedBy: "\n") {
+            let lineComponents = outputComponent.components(separatedBy: script.folder.path + "Sources/main.swift:")
+
+            guard lineComponents.count > 1 else {
+                continue
+            }
+
+            if let message = lineComponents.last?.replacingOccurrences(of: " error:", with: "") {
+                if message.contains("no such module") {
+                    if let range = message.range(of: "'[A-Za-z]+'", options: .regularExpression) {
+                        missingModule = message[range].replacingOccurrences(of: "'", with: "")
+                    }
+                }
+                messages.append(message)
+            }
+        }
+
+        return Error.failedToCompileScript(messages, missingModule)
     }
 }

--- a/Sources/MarathonCore/Script.swift
+++ b/Sources/MarathonCore/Script.swift
@@ -38,9 +38,11 @@ extension ScriptError: PrintableError {
 
             let separator = "\n- "
             var hints = ["The following error(s) occured:" + separator + errors.joined(separator: separator)]
+
             if let missingPackage = missingPackage {
                 hints.append("You can add \(missingPackage) to Marathon using 'marathon add <url-to-\(missingPackage)>'")
             }
+
             return hints
         case .installFailed(let path):
             return ["Make sure that you have write permissions to the path '\(path)' and that all parent folders exist"]
@@ -203,11 +205,9 @@ internal final class Script {
             let message = lineComponents.last!.replacingOccurrences(of: " error:", with: "")
             messages.append(message)
 
-            if message.contains("no such module") {
-                if let range = message.range(of: "'[A-Za-z]+'", options: .regularExpression) {
-                    let missingPackage = message[range].replacingOccurrences(of: "'", with: "")
-                    return Error.buildFailed(messages, missingPackage: missingPackage)
-                }
+            if let range = message.range(of: "'[A-Za-z]+'", options: .regularExpression), message.contains("no such module") {
+                let missingPackage = message[range].replacingOccurrences(of: "'", with: "")
+                return Error.buildFailed(messages, missingPackage: missingPackage)
             }
         }
 

--- a/Sources/MarathonCore/ScriptManager.swift
+++ b/Sources/MarathonCore/ScriptManager.swift
@@ -27,13 +27,13 @@ extension ScriptManagerError: PrintableError {
         }
     }
 
-    public var hint: String? {
+    public var hints: [String] {
         switch self {
         case .scriptNotFound(_):
-            return "Please check that the path is valid and try again"
+            return ["Please check that the path is valid and try again"]
         case .failedToCreatePackageFile(let folder),
              .failedToRemoveScriptFolder(let folder):
-            return "Make sure you have write permissions to the folder '\(folder.path)'"
+            return ["Make sure you have write permissions to the folder '\(folder.path)'"]
         }
     }
 }

--- a/Tests/MarathonTests/MarathonTests.swift
+++ b/Tests/MarathonTests/MarathonTests.swift
@@ -188,20 +188,23 @@ class MarathonTests: XCTestCase {
         try run(with: ["run", scriptFile.path])
     }
 
-    func testRunningScriptWithCompileErrorThrows() throws {
+    func testRunningScriptWithBuildFailedErrorThrows() throws {
         let scriptFile = try folder.createFile(named: "script.swift")
         try scriptFile.write(string: "notAFunction()")
 
-        let expectedError = ScriptError.buildFailed(["1:1: use of unresolved identifier 'notAFunction'"])
+        let expectedError = ScriptError.buildFailed(["1:1: use of unresolved identifier 'notAFunction'"], missingPackage: nil)
         assert(try run(with: ["run", scriptFile.path]), throwsError: expectedError)
     }
 
-    func testRunningScriptWithCompileErrorWhenNoSuchModuleThrows() throws {
+    func testRunningScriptWithBuildFailedErrorWhenNoSuchModuleThrows() throws {
         let scriptFile = try folder.createFile(named: "script.swift")
-        try scriptFile.write(string: "import Files")
+        let packageName = "Files"
+        try scriptFile.write(string: "import \(packageName)")
 
-        let expectedError = RunError.failedToCompileScript(["1:8: no such module 'Files'"], "Files")
+        let expectedError = ScriptError.buildFailed(["1:8: no such module '\(packageName)'"], missingPackage: packageName)
         assert(try run(with: ["run", scriptFile.path]), throwsError: expectedError)
+
+        XCTAssertTrue(expectedError.description.contains("You can add \(packageName) to Marathon using 'marathon add <url-to-\(packageName)>'"))
     }
 
     func testRunningScriptWithRuntimeErrorThrows() throws {

--- a/Tests/MarathonTests/MarathonTests.swift
+++ b/Tests/MarathonTests/MarathonTests.swift
@@ -196,6 +196,14 @@ class MarathonTests: XCTestCase {
         assert(try run(with: ["run", scriptFile.path]), throwsError: expectedError)
     }
 
+    func testRunningScriptWithCompileErrorWhenNoSuchModuleThrows() throws {
+        let scriptFile = try folder.createFile(named: "script.swift")
+        try scriptFile.write(string: "import Files")
+
+        let expectedError = RunError.failedToCompileScript(["1:8: no such module 'Files'"], "Files")
+        assert(try run(with: ["run", scriptFile.path]), throwsError: expectedError)
+    }
+
     func testRunningScriptWithRuntimeErrorThrows() throws {
         let scriptFile = try folder.createFile(named: "script.swift")
         try scriptFile.write(string: "fatalError(\"Script failed\")")


### PR DESCRIPTION
This is the improvement for #13. Now Marathon give a missing module.

For example,

```
💥  Failed to compile script
👉  The following error(s) occured:
   - 3:8: no such module 'Files'
👉  You can add Files to Marathon using 'marathon add <url-to-Files>'
```