### PR TITLE
Add `--all-packages` option in remove command

### DIFF
--- a/Sources/MarathonCore/Command.swift
+++ b/Sources/MarathonCore/Command.swift
@@ -77,7 +77,7 @@ extension Command {
         case .edit:
             return "<path-to-script> [--no-xcode] [--no-open]"
         case .remove:
-            return "<name-of-package-or-path-to-script> [--all-script-data]"
+            return "<name-of-package-or-path-to-script> [--all-script-data] [--all-packages]"
         case .run:
             return "<path-to-script> [<script-arguments...>]"
         case .install:

--- a/Sources/MarathonCore/Help.swift
+++ b/Sources/MarathonCore/Help.swift
@@ -56,7 +56,8 @@ internal final class HelpTask: Task, Executable {
                    "To not open the script at all, pass the '--no-open' flag"
         case .remove:
             return "You can use this command to clean up data for scripts or packages no longer needed. To list them, use 'marathon list'\n" +
-                   "To remove all packages, pass the '--all-script-data' flag"
+                   "To remove all script data, pass the '--all-script-data' flag" +
+                   "To remove all packages, pass the '--all-packages' flag"
         case .run:
             return "The script will be compiled and run, and any output generated will be returned"
         case .install:

--- a/Sources/MarathonCore/PackageManager.swift
+++ b/Sources/MarathonCore/PackageManager.swift
@@ -164,6 +164,12 @@ internal final class PackageManager {
         return package
     }
 
+    func removeAllPackages() throws {
+        for package in addedPackages {
+            _ = try removePackage(named: package.name)
+        }
+    }
+
     func makePackageDescription(for script: Script) throws -> String {
         guard let masterDescription = try? generatedFolder.file(named: "Package.swift").readAsString() else {
             try updatePackages()

--- a/Sources/MarathonCore/PackageManager.swift
+++ b/Sources/MarathonCore/PackageManager.swift
@@ -151,7 +151,7 @@ internal final class PackageManager {
         }
     }
 
-    func removePackage(named name: String) throws -> Package {
+    @discardableResult func removePackage(named name: String) throws -> Package {
         let packageFile = try perform(folder.file(named: name),
                                       orThrow: Error.unknownPackageForRemoval(name))
 
@@ -166,7 +166,7 @@ internal final class PackageManager {
 
     func removeAllPackages() throws {
         for package in addedPackages {
-            _ = try removePackage(named: package.name)
+            try removePackage(named: package.name)
         }
     }
 

--- a/Sources/MarathonCore/Remove.swift
+++ b/Sources/MarathonCore/Remove.swift
@@ -36,9 +36,20 @@ internal final class RemoveTask: Task, Executable {
     private typealias Error = RemoveError
 
     func execute() throws -> String {
-        if arguments.contains("--all-script-data") {
-            try scriptManager.removeAllScriptData()
-            return "🗑  Removed all script data"
+        if arguments.contains("--all-script-data") || arguments.contains("--all-packages") {
+            var deletedObjects: [String] = []
+
+            if arguments.contains("--all-script-data") {
+                try scriptManager.removeAllScriptData()
+                deletedObjects.append("all script data")
+            }
+
+            if arguments.contains("--all-packages") {
+                try packageManager.removeAllPackages()
+                deletedObjects.append("all packages")
+            }
+
+            return "🗑  Removed \(deletedObjects.joined(separator: " and "))"
         }
 
         guard let identifier = arguments.first else {

--- a/Tests/MarathonTests/MarathonTests.swift
+++ b/Tests/MarathonTests/MarathonTests.swift
@@ -95,7 +95,7 @@ class MarathonTests: XCTestCase {
         try run(with: ["add", "git@github.com:JohnSundell/Unbox.git"])
 
         let generatedFolder = try folder.subfolder(atPath: "Packages/Generated")
-        let packagesFolder = try generatedFolder.subfolder(named: "Packages")
+        let packagesFolder = try generatedFolder.subfolder(named: ".build/checkouts")
         XCTAssertEqual(packagesFolder.subfolders.count, 3)
         try XCTAssertEqual(folder.subfolder(named: "Packages").files.count, 3)
 

--- a/Tests/MarathonTests/MarathonTests.swift
+++ b/Tests/MarathonTests/MarathonTests.swift
@@ -89,6 +89,22 @@ class MarathonTests: XCTestCase {
         try XCTAssertFalse(run(with: ["list"]).contains(packageFolder.path))
     }
 
+    func testRemovingAllPackages() throws {
+        try run(with: ["add", "git@github.com:JohnSundell/Files.git"])
+        try run(with: ["add", "git@github.com:JohnSundell/Wrap.git"])
+        try run(with: ["add", "git@github.com:JohnSundell/Unbox.git"])
+
+        let generatedFolder = try folder.subfolder(atPath: "Packages/Generated")
+        let packagesFolder = try generatedFolder.subfolder(named: "Packages")
+        XCTAssertEqual(packagesFolder.subfolders.count, 3)
+        try XCTAssertEqual(folder.subfolder(named: "Packages").files.count, 3)
+
+        // Remove tht all packages
+        try run(with: ["remove", "--all-packages"])
+        XCTAssertEqual(packagesFolder.subfolders.count, 0)
+        try XCTAssertEqual(folder.subfolder(named: "Packages").files.count, 0)
+    }
+
     func testAddingLocalPackageWithDependency() throws {
         let packageFolder = try folder.createSubfolder(named: "TestPackage")
         try packageFolder.moveToAndPerform(command: "swift package init")

--- a/Tests/MarathonTests/MarathonTests.swift
+++ b/Tests/MarathonTests/MarathonTests.swift
@@ -99,7 +99,7 @@ class MarathonTests: XCTestCase {
         XCTAssertEqual(packagesFolder.subfolders.count, 3)
         try XCTAssertEqual(folder.subfolder(named: "Packages").files.count, 3)
 
-        // Remove tht all packages
+        // Remove all packages
         try run(with: ["remove", "--all-packages"])
         XCTAssertEqual(packagesFolder.subfolders.count, 0)
         try XCTAssertEqual(folder.subfolder(named: "Packages").files.count, 0)


### PR DESCRIPTION
- Add `--all-packages` to remove all packages
- Fix my typo🙇 ( `"To remove all packages, pass the '--all-script-data' flag"` )

You can remove all script data and all packages at the same time like this.

```sh
marathon remove --all-script-data --all-packages
🗑  Removed all script data and all packages
```