### PR TITLE
Enable prefetching in build and package update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 INSTALL_PATH = /usr/local/bin/marathon
 
 install:
-	swift package update
-	swift build -c release -Xswiftc -static-stdlib
+	swift package --enable-prefetching update
+	swift build --enable-prefetching -c release -Xswiftc -static-stdlib
 	cp -f .build/release/Marathon $(INSTALL_PATH)
 
 uninstall:


### PR DESCRIPTION
Added `--enable-prefetching` flag because `Marathon` updated for Swift3.1.

See also [Prefetching Dependencies](https://github.com/apple/swift-package-manager/blob/1e25310d0e3c5018e483976e6024b9ac5a37ff2b/Documentation/Usage.md#prefetching-dependencies).