### PR TITLE
Improve create script with no open option

### DIFF
--- a/Sources/MarathonCore/Create.swift
+++ b/Sources/MarathonCore/Create.swift
@@ -44,19 +44,20 @@ internal final class CreateTask: Task, Executable {
             throw Error.missingName
         }
 
-        let script = arguments.element(at: 1) ?? "import Foundation\n\n"
+        let content = arguments.element(at: 1) ?? "import Foundation\n\n"
 
-        guard let data = script.data(using: .utf8) else {
+        guard let data = content.data(using: .utf8) else {
             throw Error.failedToCreateFile(path)
         }
 
         let file = try perform(FileSystem().createFile(at: path, contents: data),
                                orThrow: Error.failedToCreateFile(path))
 
+        let script = try scriptManager.makeScript(at: file.path)
         print("🐣  Created script at \(path)")
 
         if !argumentsContainNoOpenFlag {
-            try scriptManager.script(at: file.path).edit(arguments: arguments, open: true)
+            try script.edit(arguments: arguments, open: true)
         }
     }
 }

--- a/Sources/MarathonCore/Create.swift
+++ b/Sources/MarathonCore/Create.swift
@@ -56,8 +56,6 @@ internal final class CreateTask: Task, Executable {
         let script = try scriptManager.makeScript(at: file.path)
         print("🐣  Created script at \(path)")
 
-        if !argumentsContainNoOpenFlag {
-            try script.edit(arguments: arguments, open: true)
-        }
+        try script.edit(arguments: arguments, open: !argumentsContainNoOpenFlag)
     }
 }

--- a/Sources/MarathonCore/Edit.swift
+++ b/Sources/MarathonCore/Edit.swift
@@ -41,9 +41,6 @@ internal final class EditTask: Task, Executable {
         }
 
         let script = try scriptManager.makeScript(at: path)
-
-        if !argumentsContainNoOpenFlag {
-            try script.edit(arguments: arguments, open: true)
-        }
+        try script.edit(arguments: arguments, open: !argumentsContainNoOpenFlag)
     }
 }

--- a/Sources/MarathonCore/Edit.swift
+++ b/Sources/MarathonCore/Edit.swift
@@ -40,7 +40,10 @@ internal final class EditTask: Task, Executable {
             throw Error.missingPath
         }
 
-        let script = try scriptManager.script(at: path)
-        try script.edit(arguments: arguments, open: !argumentsContainNoOpenFlag)
+        let script = try scriptManager.makeScript(at: path)
+
+        if !argumentsContainNoOpenFlag {
+            try script.edit(arguments: arguments, open: true)
+        }
     }
 }

--- a/Sources/MarathonCore/Install.swift
+++ b/Sources/MarathonCore/Install.swift
@@ -38,7 +38,7 @@ internal class InstallTask: Task, Executable {
             throw Error.missingPath
         }
 
-        let script = try scriptManager.script(at: path)
+        let script = try scriptManager.makeScript(at: path)
         let installPath = makeInstallPath(for: script)
         let installed = try script.install(at: installPath, confirmBeforeOverwriting: !arguments.contains("--force"))
 

--- a/Sources/MarathonCore/Run.swift
+++ b/Sources/MarathonCore/Run.swift
@@ -47,7 +47,7 @@ internal class RunTask: Task, Executable {
             throw Error.missingPath
         }
 
-        let script = try scriptManager.script(at: path)
+        let script = try scriptManager.makeScript(at: path)
         try script.build()
 
         do {

--- a/Sources/MarathonCore/ScriptManager.swift
+++ b/Sources/MarathonCore/ScriptManager.swift
@@ -59,7 +59,7 @@ internal final class ScriptManager {
 
     // MARK: - API
 
-    func script(at path: String) throws -> Script {
+    func makeScript(at path: String) throws -> Script {
         let file = try perform(File(path: path), orThrow: Error.scriptNotFound(path))
         let identifier = scriptIdentifier(from: file.path)
         let name = identifier.components(separatedBy: "-").last!.capitalized


### PR DESCRIPTION
For example,

```sh
marathon create helloWorld "import Foundation; print(\"Hello world\")" --no-open
marathon list
// no `helloWorld` script here!!
```
Fixed the above issue and Renamed some methods for clarity.
