### PR TITLE
Add script to list correctly if creating with --no-open option

### DIFF
--- a/Sources/MarathonCore/Create.swift
+++ b/Sources/MarathonCore/Create.swift
@@ -44,20 +44,18 @@ internal final class CreateTask: Task, Executable {
             throw Error.missingName
         }
 
-        let script = arguments.element(at: 1) ?? "import Foundation\n\n"
+        let content = arguments.element(at: 1) ?? "import Foundation\n\n"
 
-        guard let data = script.data(using: .utf8) else {
+        guard let data = content.data(using: .utf8) else {
             throw Error.failedToCreateFile(path)
         }
 
         let file = try perform(FileSystem().createFile(at: path, contents: data),
                                orThrow: Error.failedToCreateFile(path))
 
+        let script = try scriptManager.script(at: file.path, usingPrinter: print)
         print("🐣  Created script at \(path)")
 
-        if !argumentsContainNoOpenFlag {
-            let script = try scriptManager.script(at: file.path, usingPrinter: print)
-            try script.edit(arguments: arguments, open: true)
-        }
+        try script.edit(arguments: arguments, open: !argumentsContainNoOpenFlag)
     }
 }

--- a/Tests/MarathonTests/MarathonTests.swift
+++ b/Tests/MarathonTests/MarathonTests.swift
@@ -317,6 +317,7 @@ class MarathonTests: XCTestCase {
 
         try run(with: ["create", scriptPath, "--no-open"])
         try XCTAssertFalse(scriptFolder.file(named: "script.swift").read().isEmpty)
+        try XCTAssertTrue(run(with: ["list"]).contains(scriptPath))
     }
 
     // MARK: - Editing scripts


### PR DESCRIPTION
For example,

```sh
marathon create helloWorld "import Foundation; print(\"Hello world\")" --no-open
marathon list
// no `helloWorld` script here!!
```
Fixed the above issue.
Based on your review, I decided to use `script(at:usingPriner:)`! Thanks:)

## TODO
- [x] Add tests.
