### PR TITLE
🐧 Improve Linux support 

### DIFF
--- a/Sources/MarathonCore/Script.swift
+++ b/Sources/MarathonCore/Script.swift
@@ -8,6 +8,9 @@ import Foundation
 import Files
 import ShellOut
 import Require
+#if os(Linux)
+    import Dispatch
+#endif
 
 // MARK: - Error
 

--- a/Tests/MarathonTests/MarathonTests.swift
+++ b/Tests/MarathonTests/MarathonTests.swift
@@ -609,7 +609,40 @@ fileprivate extension MarathonTests {
 extension MarathonTests {
     static var allTests : [(String, (MarathonTests) -> () throws -> Void)] {
         return [
-            ("testExample", testExample),
+            ("InvalidCommandThrows", testInvalidCommandThrows),
+            ("AddingAndRemovingRemotePackage", testAddingAndRemovingRemotePackage),
+            ("AddingAndRemovingLocalPackage", testAddingAndRemovingLocalPackage),
+            ("RemovingAllPackages", testRemovingAllPackages),
+            ("AddingLocalPackageWithDependency", testAddingLocalPackageWithDependency),
+            ("AddingLocalPackageWithUnsortedVersionsContainingLetters", testAddingLocalPackageWithUnsortedVersionsContainingLetters),
+            ("AddingAlreadyAddedPackageThrows", testAddingAlreadyAddedPackageThrows),
+            ("RunningScriptWithoutPathThrows", testRunningScriptWithoutPathThrows),
+            ("testRunningScript", testRunningScript),
+            ("testRunningScriptWithNewDependency", testRunningScriptWithNewDependency),
+            ("testRunningScriptWithBuildFailedErrorThrows", testRunningScriptWithBuildFailedErrorThrows),
+            ("testRunningScriptWithBuildFailedErrorWhenNoSuchModuleThrows", testRunningScriptWithBuildFailedErrorWhenNoSuchModuleThrows),
+            ("testRunningScriptWithRuntimeErrorThrows", testRunningScriptWithRuntimeErrorThrows),
+            ("testRunningScriptReturnsOutput", testRunningScriptReturnsOutput),
+            ("testPassingArgumentsToScript", testPassingArgumentsToScript),
+            ("testCurrentWorkingDirectoryOfScriptIsExecutionFolder", testCurrentWorkingDirectoryOfScriptIsExecutionFolder),
+            ("testScriptWithLargeAmountOfOutput", testScriptWithLargeAmountOfOutput),
+            ("testInstallingLocalScript", testInstallingLocalScript),
+            ("testInstallingRemoteScriptWithDependencies", testInstallingRemoteScriptWithDependencies),
+            ("testCreatingScriptWithoutNameThrows", testCreatingScriptWithoutNameThrows),
+            ("testCreatingScriptWithName", testCreatingScriptWithName),
+            ("testCreatingScriptWithPath", testCreatingScriptWithPath),
+            ("testCreatingScriptWithContent", testCreatingScriptWithContent),
+            ("testCreatingAndRunningScriptInFolderWithSpaces", testCreatingAndRunningScriptInFolderWithSpaces),
+            ("testEditingScriptWithoutPathThrows", testEditingScriptWithoutPathThrows),
+            ("testEditingScriptWithoutXcode", testEditingScriptWithoutXcode),
+            ("testRemovingScriptCacheData", testRemovingScriptCacheData),
+            ("testRemovingScriptCacheDataForDeletedScript", testRemovingScriptCacheDataForDeletedScript),
+            ("testRemovingAllScriptData", testRemovingAllScriptData),
+            ("testUpdatingPackages", testUpdatingPackages),
+            ("testUsingMarathonfileToInstallDependencies", testUsingMarathonfileToInstallDependencies),
+            ("testAddingLocalPackageUsingRelativePathInMarathonfile", testAddingLocalPackageUsingRelativePathInMarathonfile),
+            ("testAddingOtherScriptAsDependencyUsingMarathonfile", testAddingOtherScriptAsDependencyUsingMarathonfile),
+            ("testIncorrectlyFormattedMarathonfileThrows", testIncorrectlyFormattedMarathonfileThrows)
         ]
     }
 }


### PR DESCRIPTION
To avoid compatibility errors with Linux ([issue37](https://github.com/JohnSundell/Marathon/issues/37)) I updated `Script.swift` to import `Dispatch` if the OS is Linux to avoid the error `error: no such module 'Dispatch'` during the build.

```swift
import Foundation
import Files
import ShellOut
import Require
#if os(Linux)
    import Dispatch
#endif
``` 

This fix resolves the build issue so you can build and run Marathon on a Linux machine. Unfortunately the `install` doesn't work and when I try to install a working script I had this error:
`💥  Failed to compile script`

I also updated the `MarathonTests.swift` to run all the test except `testEditingScriptWithXcode` and 4 of 34 tests failed on a Linux machine with Ubuntu 16.04
```
Test Suite 'MarathonTests' failed at 12:25:50.019
	 Executed 34 tests, with 4 failures (3 unexpected) in 194.676 (194.676) seconds
Test Suite 'debug.xctest' failed at 12:25:50.019
	 Executed 34 tests, with 4 failures (3 unexpected) in 194.676 (194.676) seconds
Test Suite 'All tests' failed at 12:25:50.019
	 Executed 34 tests, with 4 failures (3 unexpected) in 194.676 (194.676) seconds
```

Those tests are all related to the `install` command:
```
Test Case 'MarathonTests.AddingAndRemovingRemotePackage' started at 12:37:40.118
<EXPR>:0: error: MarathonTests.AddingAndRemovingRemotePackage : threw error "💥  Cannot remove package 'files' - no such package has been added
👉  Did you mean to remove the cache data for a script? If so, add '.swift' to its path
   To list all added packages run 'marathon list'"
Test Case 'MarathonTests.AddingAndRemovingRemotePackage' failed (9.49 seconds)
```
```
Test Case 'MarathonTests.testInstallingLocalScript' started at 12:40:04.579
<EXPR>:0: error: MarathonTests.testInstallingLocalScript : threw error "💥  Failed to compile script"
Test Case 'MarathonTests.testInstallingLocalScript' failed (18.473 seconds)
```
```
Test Case 'MarathonTests.testInstallingRemoteScriptWithDependencies' started at 12:40:23.052
<EXPR>:0: error: MarathonTests.testInstallingRemoteScriptWithDependencies : threw error "💥  Failed to compile script"
Test Case 'MarathonTests.testInstallingRemoteScriptWithDependencies' failed (17.406 seconds)
```
```
Test Case 'MarathonTests.testUsingMarathonfileToInstallDependencies' started at 12:25:17.879
/home/darthpelo/Marathon/Tests/MarathonTests/MarathonTests.swift:521: error: MarathonTests.testUsingMarathonfileToInstallDependencies : XCTAssertEqual failed: ("4") is not equal to ("2") - 
Test Case 'MarathonTests.testUsingMarathonfileToInstallDependencies' failed (28.189 seconds)
```

On macOS all the tests are green.