### PR TITLE
🐧 Fix install bug on Linux platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,14 @@ $ swift build -c release -Xswiftc -static-stdlib
 $ cp -f .build/release/Marathon /usr/local/bin/marathon
 ```
 
+On a Linux machine don't use Make but the Swift Package Manager:
+```
+$ git clone git@github.com:JohnSundell/Marathon.git
+$ cd Marathon
+$ swift build -c release
+$ cp -f .build/release/Marathon /usr/local/bin/marathon
+```
+
 If you encounter a permissions failure while installing, you may need to prepend `sudo` to the commands.
 To update Marathon, simply repeat any of the above two series of commands, except cloning the repo.
 

--- a/Sources/MarathonCore/Install.swift
+++ b/Sources/MarathonCore/Install.swift
@@ -42,8 +42,11 @@ internal class InstallTask: Task, Executable {
         let installPath = makeInstallPath(for: script)
 
         printer.reportProgress("Compiling script...")
-        try script.build(withArguments: ["-c", "release", "-Xswiftc", "-static-stdlib"])
-
+        #if os(Linux)
+            try script.build(withArguments: ["-c", "release"])
+        #else
+            try script.build(withArguments: ["-c", "release", "-Xswiftc", "-static-stdlib"])
+        #endif
         printer.reportProgress("Installing binary...")
         let installed = try script.install(at: installPath, confirmBeforeOverwriting: !arguments.contains("--force"))
 


### PR DESCRIPTION
This PR fix the `install` bug of pull request #48.

With this PR it's possible to install a script on your Linux machine 🎉.

```bash
alessioroberto@ Marathon (linux-support)$ .build/debug/Marathon install ../testInstall.swift
🏃  Compiling script...
   Installing binary...
💻  ../testInstall.swift installed at testInstall
alessioroberto@ Marathon (linux-support)$ testInstall
``` 

`swift test` on my Ubuntu has, again, only 1 unexpected failures:
```bash
Test Case 'MarathonTests.testUsingMarathonfileToInstallDependencies' started at 00:09:15.372
/home/alessioroberto/Documents/Marathon/Tests/MarathonTests/MarathonTests.swift:521: error: MarathonTests.testUsingMarathonfileToInstallDependencies : XCTAssertEqual failed: ("4") is not equal to ("2") - 
Test Case 'MarathonTests.testUsingMarathonfileToInstallDependencies' failed (29.431 seconds)
```
Instead `testInstallingLocalScript` and `testInstallingRemoteScriptWithDependencies` now are ✅