### PR TITLE
Create an independent folder in Tests

### DIFF
--- a/Tests/MarathonTests/MarathonTests.swift
+++ b/Tests/MarathonTests/MarathonTests.swift
@@ -644,7 +644,7 @@ class MarathonTests: XCTestCase {
 
 fileprivate extension MarathonTests {
     func createFolder() -> Folder {
-        let folderName = ".marathonTests"
+        let folderName = ".marathonTests-\(NSUUID().uuidString)"
 
         if let existingFolder = try? FileSystem().homeFolder.subfolder(named: folderName) {
             try! existingFolder.empty(includeHidden: true)

--- a/Tests/MarathonTests/MarathonTests.swift
+++ b/Tests/MarathonTests/MarathonTests.swift
@@ -644,14 +644,16 @@ class MarathonTests: XCTestCase {
 
 fileprivate extension MarathonTests {
     func createFolder() -> Folder {
-        let folderName = ".marathonTests-\(NSUUID().uuidString)"
+        let folderName = ".marathonTests"
+        let subFolderName = NSUUID().uuidString
 
-        if let existingFolder = try? FileSystem().homeFolder.subfolder(named: folderName) {
+        if let existingFolder = try? FileSystem().homeFolder.subfolder(atPath: folderName + "/" + subFolderName) {
             try! existingFolder.empty(includeHidden: true)
             return existingFolder
         }
 
-        return try! FileSystem().homeFolder.createSubfolder(named: folderName)
+        let parentFolder = try! FileSystem().homeFolder.createSubfolderIfNeeded(withName: folderName)
+        return try! parentFolder.createSubfolder(named: subFolderName)
     }
 
     @discardableResult func run(with arguments: [String]) throws -> String {


### PR DESCRIPTION
This change allows us to use `--parallel` option.

I'll replace `swift test` with `swift test --parallel` in `buddybuild_postbuild.sh` if you agree.

```sh
$ swift test --parallel
Compile Swift Module 'MarathonTests' (3 sources)
Linking ./.build/debug/MarathonPackageTests.xctest/Contents/MacOS/MarathonPackageTests
                                                                                       Tests
100% [===============================================================================================================================================================]
MarathonTests.MarathonTests/testUsingMarathonfileToInstallDependencies
```