### PR TITLE
Fix printing of URLs on Linux.

### DIFF
--- a/Sources/MarathonCore/List.swift
+++ b/Sources/MarathonCore/List.swift
@@ -19,7 +19,7 @@ internal final class ListTask: Task, Executable {
             output.append(title + "\n" + title.dashesWithMatchingLength + "\n")
 
             for package in packageManager.addedPackages {
-                output.append("\(package.name) (\(package.url))\n")
+                output.append("\(package.name) (\(package.url.absoluteString))\n")
             }
 
             output.append("\n")

--- a/Sources/MarathonCore/PackageManager.swift
+++ b/Sources/MarathonCore/PackageManager.swift
@@ -28,9 +28,9 @@ extension PackageManagerError: PrintableError {
     public var message: String {
         switch self {
         case .failedToResolveLatestVersion(let url):
-            return "Could not resolve the latest version for package at '\(url)'"
+            return "Could not resolve the latest version for package at '\(url.absoluteString)'"
         case .failedToResolveName(let url):
-            return "Could not resolve the name of package at '\(url)'"
+            return "Could not resolve the name of package at '\(url.absoluteString)'"
         case .packageAlreadyAdded(let name):
             return "A package named '\(name)' has already been added"
         case .failedToSavePackageFile(let name, _):


### PR DESCRIPTION
Before:
```
> marathon list
📦  Packages
-----------
SwiftShell (<CFURL 0x17d8d60 [0x7f4c35d83840]>{string = https://github.com/kareman/SwiftShell.git, encoding = 134217984, base = (null)})

👉  To remove either a package or the cached data for a script, use 'marathon remove'
```

After:
```
> marathon list
📦  Packages
-----------
SwiftShell (https://github.com/kareman/SwiftShell.git)

👉  To remove either a package or the cached data for a script, use 'marathon remove'
```