### PR TITLE
Introduce Targeted Extensions

### DIFF
--- a/Sources/Marathon/main.swift
+++ b/Sources/Marathon/main.swift
@@ -9,7 +9,7 @@ import MarathonCore
 import Require
 
 do {
-    try Marathon.run()
+    try MarathonCore.run()
 } catch {
     let errorData = "\(error)".data(using: .utf8).require()
     FileHandle.standardError.write(errorData)

--- a/Sources/MarathonCore/Folder+Marathon.swift
+++ b/Sources/MarathonCore/Folder+Marathon.swift
@@ -7,14 +7,12 @@
 import Foundation
 import Files
 
-internal extension Folder {
+internal extension Marathon where Base == Folder {
     @discardableResult func moveToAndPerform(command: String, printer: Printer) throws -> String {
-        return try shellOut(to: command, in: self, printer: printer)
+        return try shellOut(to: command, in: base.self, printer: printer)
     }
-}
 
-internal extension Folder {
     func createSymlink(to originalPath: String, at linkPath: String, printer: Printer) throws {
-        try shellOut(to: "ln -s \"\(originalPath)\" \"\(linkPath)\"", in: self, printer: printer)
+        try shellOut(to: "ln -s \"\(originalPath)\" \"\(linkPath)\"", in: base.self, printer: printer)
     }
 }

--- a/Sources/MarathonCore/Help.swift
+++ b/Sources/MarathonCore/Help.swift
@@ -15,7 +15,7 @@ internal final class HelpTask: Task, Executable {
         let command = try Command(arguments: arguments, index: 0)
         let title = makeTitle(for: command)
         let message = makeMessage(for: command)
-        var output = title + "\n" + title.dashesWithMatchingLength
+        var output = title + "\n" + title.mt.dashesWithMatchingLength
 
         if command == .help {
             output.append("-\n")
@@ -24,14 +24,14 @@ internal final class HelpTask: Task, Executable {
             output.append("\n" + command.description + "\n\n")
             output.append("👉  Usage: 'marathon \(command.rawValue)")
 
-            if command.usageText.length > 0 {
+            if command.usageText.mt.length > 0 {
                 output.append(" \(command.usageText)")
             }
 
             output.append("'")
 
             if !message.isEmpty {
-                output.append("\n\n" + message.withIndentedNewLines(prefix: "ℹ️  "))
+                output.append("\n\n" + message.mt.withIndentedNewLines(prefix: "ℹ️  "))
             }
         }
 
@@ -101,7 +101,7 @@ private extension Command {
             return title
         }
 
-        let paddingNeeded = 10 - rawValue.length
+        let paddingNeeded = 10 - rawValue.mt.length
 
         guard paddingNeeded > 0 else {
             return title

--- a/Sources/MarathonCore/List.swift
+++ b/Sources/MarathonCore/List.swift
@@ -16,7 +16,7 @@ internal final class ListTask: Task, Executable {
 
         if !packages.isEmpty {
             let title = "📦  Packages"
-            output.append(title + "\n" + title.dashesWithMatchingLength + "\n")
+            output.append(title + "\n" + title.mt.dashesWithMatchingLength + "\n")
 
             for package in packageManager.addedPackages {
                 output.append("\(package.name) (\(package.url.absoluteString))\n")
@@ -28,7 +28,7 @@ internal final class ListTask: Task, Executable {
 
         if !scriptPaths.isEmpty {
             let title = "📄  Scripts"
-            output.append(title + "\n" + title.dashesWithMatchingLength + "\n")
+            output.append(title + "\n" + title.mt.dashesWithMatchingLength + "\n")
 
             for path in scriptPaths {
                 output.append("\(path)\n")

--- a/Sources/MarathonCore/Marathon.swift
+++ b/Sources/MarathonCore/Marathon.swift
@@ -7,95 +7,24 @@
 import Foundation
 import Files
 
-public final class Marathon {
-    public enum Error: Swift.Error {
-        case couldNotPerformSetup(String)
-    }
-
-    private struct Folders {
-        let module: Folder
-        let scripts: Folder
-        let packages: Folder
-    }
-
-    // MARK: - API
-
-    public static func run(with arguments: [String] = CommandLine.arguments,
-                           folderPath: String = "~/.marathon",
-                           printFunction: @escaping PrintFunction = { print($0) }) throws {
-        let task = try resolveTask(for: arguments, folderPath: folderPath, printFunction: printFunction)
-        try task.execute()
-    }
-
-    // MARK: - Private
-
-    private static func resolveTask(for arguments: [String],
-                                    folderPath: String,
-                                    printFunction: @escaping PrintFunction) throws -> Executable {
-        let command = try Command(arguments: arguments)
-        let printer = makePrinter(using: printFunction, command: command, arguments: arguments)
-        let fileSystem = FileSystem()
-
-        do {
-            let rootFolder = try fileSystem.createFolderIfNeeded(at: folderPath)
-            let packageFolder = try rootFolder.createSubfolderIfNeeded(withName: "Packages")
-            let scriptFolder = try rootFolder.createSubfolderIfNeeded(withName: "Scripts")
-
-            let packageManager = try PackageManager(folder: packageFolder, printer: printer)
-            let scriptManager = try ScriptManager(folder: scriptFolder, packageManager: packageManager, printer: printer)
-
-            return command.makeTaskClosure(fileSystem.currentFolder,
-                                           Array(arguments.dropFirst(2)),
-                                           scriptManager, packageManager,
-                                           printer)
-        } catch {
-            throw Error.couldNotPerformSetup(folderPath)
-        }
-    }
-
-    private static func makePrinter(using printFunction: @escaping PrintFunction,
-                                    command: Command,
-                                    arguments: [String]) -> Printer {
-        let progressFunction = makeProgressPrintingFunction(using: printFunction, command: command, arguments: arguments)
-        let verboseFunction = makeVerbosePrintingFunction(using: progressFunction, arguments: arguments)
-
-        return Printer(
-            outputFunction: printFunction,
-            progressFunction: progressFunction,
-            verboseFunction: verboseFunction
-        )
-    }
-
-    private static func makeProgressPrintingFunction(using printFunction: @escaping PrintFunction,
-                                                     command: Command,
-                                                     arguments: [String]) -> VerbosePrintFunction {
-        var isFirstOutput = true
-        let shouldPrint = command.allowsProgressOutput || arguments.contains("--verbose")
-
-        return { (messageExpression: () -> String) in
-            guard shouldPrint else {
-                return
-            }
-
-            let message = messageExpression()
-            printFunction(message.withIndentedNewLines(prefix: isFirstOutput ? "🏃  " : "   "))
-
-            isFirstOutput = false
-        }
-    }
-
-    private static func makeVerbosePrintingFunction(using progressFunction: @escaping VerbosePrintFunction,
-                                                    arguments: [String]) -> VerbosePrintFunction {
-        let allowVerboseOutput = arguments.contains("--verbose")
-
-        return { (messageExpression: () -> String) in
-            guard allowVerboseOutput else {
-                return
-            }
-
-            // Make text italic
-            let message = "\u{001B}[0;3m\(messageExpression())\u{001B}[0;23m"
-            progressFunction(message)
-        }
+public final class Marathon<Base> {
+    let base: Base
+    public init(_ base: Base) {
+        self.base = base
     }
 }
+
+public protocol MarathonCompatible {
+    associatedtype CompatibleType
+    var mt: CompatibleType { get }
+}
+
+public extension MarathonCompatible {
+    public var mt: Marathon<Self> {
+        return Marathon(self)
+    }
+}
+
+extension String: MarathonCompatible { }
+extension URL: MarathonCompatible { }
+extension Folder: MarathonCompatible { }

--- a/Sources/MarathonCore/MarathonCore.swift
+++ b/Sources/MarathonCore/MarathonCore.swift
@@ -1,0 +1,101 @@
+/**
+ *  Marathon
+ *  Copyright (c) John Sundell 2017
+ *  Licensed under the MIT license. See LICENSE file.
+ */
+
+import Foundation
+import Files
+
+public final class MarathonCore {
+    public enum Error: Swift.Error {
+        case couldNotPerformSetup(String)
+    }
+
+    private struct Folders {
+        let module: Folder
+        let scripts: Folder
+        let packages: Folder
+    }
+
+    // MARK: - API
+
+    public static func run(with arguments: [String] = CommandLine.arguments,
+                           folderPath: String = "~/.marathon",
+                           printFunction: @escaping PrintFunction = { print($0) }) throws {
+        let task = try resolveTask(for: arguments, folderPath: folderPath, printFunction: printFunction)
+        try task.execute()
+    }
+
+    // MARK: - Private
+
+    private static func resolveTask(for arguments: [String],
+                                    folderPath: String,
+                                    printFunction: @escaping PrintFunction) throws -> Executable {
+        let command = try Command(arguments: arguments)
+        let printer = makePrinter(using: printFunction, command: command, arguments: arguments)
+        let fileSystem = FileSystem()
+
+        do {
+            let rootFolder = try fileSystem.createFolderIfNeeded(at: folderPath)
+            let packageFolder = try rootFolder.createSubfolderIfNeeded(withName: "Packages")
+            let scriptFolder = try rootFolder.createSubfolderIfNeeded(withName: "Scripts")
+
+            let packageManager = try PackageManager(folder: packageFolder, printer: printer)
+            let scriptManager = try ScriptManager(folder: scriptFolder, packageManager: packageManager, printer: printer)
+
+            return command.makeTaskClosure(fileSystem.currentFolder,
+                                           Array(arguments.dropFirst(2)),
+                                           scriptManager, packageManager,
+                                           printer)
+        } catch {
+            throw Error.couldNotPerformSetup(folderPath)
+        }
+    }
+
+    private static func makePrinter(using printFunction: @escaping PrintFunction,
+                                    command: Command,
+                                    arguments: [String]) -> Printer {
+        let progressFunction = makeProgressPrintingFunction(using: printFunction, command: command, arguments: arguments)
+        let verboseFunction = makeVerbosePrintingFunction(using: progressFunction, arguments: arguments)
+
+        return Printer(
+            outputFunction: printFunction,
+            progressFunction: progressFunction,
+            verboseFunction: verboseFunction
+        )
+    }
+
+    private static func makeProgressPrintingFunction(using printFunction: @escaping PrintFunction,
+                                                     command: Command,
+                                                     arguments: [String]) -> VerbosePrintFunction {
+        var isFirstOutput = true
+        let shouldPrint = command.allowsProgressOutput || arguments.contains("--verbose")
+
+        return { (messageExpression: () -> String) in
+            guard shouldPrint else {
+                return
+            }
+
+            let message = messageExpression()
+            printFunction(message.mt.withIndentedNewLines(prefix: isFirstOutput ? "🏃  " : "   "))
+
+            isFirstOutput = false
+        }
+    }
+
+    private static func makeVerbosePrintingFunction(using progressFunction: @escaping VerbosePrintFunction,
+                                                    arguments: [String]) -> VerbosePrintFunction {
+        let allowVerboseOutput = arguments.contains("--verbose")
+
+        return { (messageExpression: () -> String) in
+            guard allowVerboseOutput else {
+                return
+            }
+
+            // Make text italic
+            let message = "\u{001B}[0;3m\(messageExpression())\u{001B}[0;23m"
+            progressFunction(message)
+        }
+    }
+}

--- a/Sources/MarathonCore/MarathonFile.swift
+++ b/Sources/MarathonCore/MarathonFile.swift
@@ -51,7 +51,7 @@ internal struct MarathonFile {
 
             let url = try absoluteURL(from: urlString, file: file)
 
-            if url.isForScript {
+            if url.mt.isForScript {
                 scriptURLs.append(url)
             } else {
                 packageURLs.append(url)
@@ -66,7 +66,7 @@ internal struct MarathonFile {
             throw Error.failedToRead(file)
         }
 
-        guard !url.isForRemoteRepository else {
+        guard !url.mt.isForRemoteRepository else {
             return url
         }
 
@@ -87,7 +87,7 @@ private extension File {
     func sibling(at url: URL) throws -> FileSystem.Item {
         let parent = self.parent.require()
 
-        if url.isForScript {
+        if url.mt.isForScript {
             return try parent.file(atPath: url.absoluteString)
         } else {
             return try parent.subfolder(atPath: url.absoluteString)

--- a/Sources/MarathonCore/Package.swift
+++ b/Sources/MarathonCore/Package.swift
@@ -33,7 +33,7 @@ internal extension Package {
     }
 
     var folderPrefix: String {
-        if url.isForRemoteRepository {
+        if url.mt.isForRemoteRepository {
             return "\(name).git-"
         }
 

--- a/Sources/MarathonCore/PackageManager.swift
+++ b/Sources/MarathonCore/PackageManager.swift
@@ -51,7 +51,7 @@ extension PackageManagerError: PrintableError {
         case .failedToResolveLatestVersion(let url):
             var hint = "Make sure that the package you're trying to add is reachable, and has at least one tagged release"
 
-            if !url.isForRemoteRepository {
+            if !url.mt.isForRemoteRepository {
                 hint += "\nYou can make a release by using 'git tag <version>' in your package's repository"
             }
 
@@ -176,15 +176,15 @@ internal final class PackageManager {
         let buildFolder = try folder.createSubfolderIfNeeded(withName: ".build")
 
         if !buildFolder.containsSubfolder(named: "checkouts") {
-            try buildFolder.createSymlink(to: checkoutsFolder.path, at: "checkouts", printer: printer)
+            try buildFolder.mt.createSymlink(to: checkoutsFolder.path, at: "checkouts", printer: printer)
         }
 
         if !buildFolder.containsSubfolder(named: "repositories") {
-            try buildFolder.createSymlink(to: repositoriesFolder.path, at: "repositories", printer: printer)
+            try buildFolder.mt.createSymlink(to: repositoriesFolder.path, at: "repositories", printer: printer)
         }
 
         if !buildFolder.containsFile(named: "workspace-state.json") {
-            try buildFolder.createSymlink(to: workspaceStateFile.path, at: "workspace-state.json", printer: printer)
+            try buildFolder.mt.createSymlink(to: workspaceStateFile.path, at: "workspace-state.json", printer: printer)
         }
     }
 
@@ -220,7 +220,7 @@ internal final class PackageManager {
 
     private func nameOfPackage(at url: URL) throws -> String {
         do {
-            if url.isForRemoteRepository {
+            if url.mt.isForRemoteRepository {
                 return try nameOfRemotePackage(at: url)
             }
             
@@ -261,7 +261,7 @@ internal final class PackageManager {
 
         printer.reportProgress("Cloning \(url.absoluteString)...")
 
-        try temporaryFolder.moveToAndPerform(command: "git clone \(url.absoluteString) Clone -q", printer: printer)
+        try temporaryFolder.mt.moveToAndPerform(command: "git clone \(url.absoluteString) Clone -q", printer: printer)
         let clone = try temporaryFolder.subfolder(named: "Clone")
         let name = try nameOfPackage(in: clone)
         try clone.delete()
@@ -270,7 +270,7 @@ internal final class PackageManager {
     }
 
     private func absoluteRepositoryURL(from url: URL) -> URL {
-        guard !url.isForRemoteRepository else {
+        guard !url.mt.isForRemoteRepository else {
             return url
         }
 
@@ -288,7 +288,7 @@ internal final class PackageManager {
 
         do {
             try generateMasterPackageDescription()
-            try generatedFolder.moveToAndPerform(command: "swift package --enable-prefetching update", printer: printer)
+            try generatedFolder.mt.moveToAndPerform(command: "swift package --enable-prefetching update", printer: printer)
             try generatedFolder.createSubfolderIfNeeded(withName: "Packages")
         } catch {
             throw Error.failedToUpdatePackages(folder)

--- a/Sources/MarathonCore/PrintableError.swift
+++ b/Sources/MarathonCore/PrintableError.swift
@@ -20,7 +20,7 @@ public extension PrintableError {
         var description = "💥  \(message)"
 
         if !hints.isEmpty {
-            hints.forEach { description.append("\n" + $0.withIndentedNewLines(prefix: "👉  ")) }
+            hints.forEach { description.append("\n" + $0.mt.withIndentedNewLines(prefix: "👉  ")) }
         }
 
         return description

--- a/Sources/MarathonCore/Script.swift
+++ b/Sources/MarathonCore/Script.swift
@@ -81,7 +81,7 @@ internal final class Script {
     func build(withArguments arguments: [String] = []) throws {
         do {
             let command = "swift build --enable-prefetching " + arguments.joined(separator: " ")
-            try folder.moveToAndPerform(command: command, printer: printer)
+            try folder.mt.moveToAndPerform(command: command, printer: printer)
         } catch {
             throw formatBuildError(error as! ShellOutError)
         }
@@ -90,7 +90,7 @@ internal final class Script {
     func run(in executionFolder: Folder, with arguments: [String]) throws -> String {
         let scriptPath = folder.path + ".build/debug/" + name
         let command = scriptPath + " " + arguments.joined(separator: " ")
-        return try executionFolder.moveToAndPerform(command: command, printer: printer)
+        return try executionFolder.mt.moveToAndPerform(command: command, printer: printer)
     }
 
     func install(at path: String, confirmBeforeOverwriting: Bool) throws -> Bool {
@@ -114,7 +114,7 @@ internal final class Script {
             }
 
             let buildFolder = try folder.subfolder(atPath: ".build/release")
-            try buildFolder.moveToAndPerform(command: "cp -f \(name) \(path)", printer: printer)
+            try buildFolder.mt.moveToAndPerform(command: "cp -f \(name) \(path)", printer: printer)
 
             return true
         } catch {
@@ -171,12 +171,12 @@ internal final class Script {
     }
 
     private func generateXcodeProject() throws -> Folder {
-        try folder.moveToAndPerform(command: "swift package generate-xcodeproj", printer: printer)
+        try folder.mt.moveToAndPerform(command: "swift package generate-xcodeproj", printer: printer)
         return try folder.subfolder(named: name + ".xcodeproj")
     }
 
     private func expandSymlink() throws -> String {
-        return try folder.moveToAndPerform(command: "readlink OriginalFile", printer: printer)
+        return try folder.mt.moveToAndPerform(command: "readlink OriginalFile", printer: printer)
     }
 
     private func startCopyLoop() {

--- a/Sources/MarathonCore/ScriptManager.swift
+++ b/Sources/MarathonCore/ScriptManager.swift
@@ -87,7 +87,7 @@ internal final class ScriptManager {
 
     func downloadScript(from url: URL) throws -> Script {
         do {
-            let url = url.transformIfNeeded()
+            let url = url.mt.transformIfNeeded()
 
             printer.reportProgress("Downloading script...")
             let data = try Data(contentsOf: url)
@@ -100,7 +100,7 @@ internal final class ScriptManager {
             temporaryScriptFiles.append(file)
 
             printer.reportProgress("Resolving Marathonfile...")
-            if let parentURL = url.parent {
+            if let parentURL = url.mt.parent {
                 let marathonFileURL = URL(string: parentURL.absoluteString + "Marathonfile").require()
 
                 if let marathonFileData = try? Data(contentsOf: marathonFileURL) {
@@ -169,7 +169,7 @@ internal final class ScriptManager {
         try packageManager.symlinkPackages(to: scriptFolder)
 
         if (try? scriptFolder.file(named: "OriginalFile")) == nil {
-            try scriptFolder.createSymlink(to: file.path, at: "OriginalFile", printer: printer)
+            try scriptFolder.mt.createSymlink(to: file.path, at: "OriginalFile", printer: printer)
         }
 
         let sourcesFolder = try scriptFolder.createSubfolderIfNeeded(withName: "Sources")
@@ -198,7 +198,7 @@ internal final class ScriptManager {
 
     private func makeManagedScriptPathList() -> [String] {
         return cacheFolder.subfolders.flatMap { scriptFolder in
-            guard let path = try? scriptFolder.moveToAndPerform(command: "readlink OriginalFile", printer: printer) else {
+            guard let path = try? scriptFolder.mt.moveToAndPerform(command: "readlink OriginalFile", printer: printer) else {
                 return nil
             }
 

--- a/Sources/MarathonCore/String+Marathon.swift
+++ b/Sources/MarathonCore/String+Marathon.swift
@@ -6,9 +6,9 @@
 
 import Foundation
 
-internal extension String {
+internal extension Marathon where Base == String {
     var length: String.IndexDistance {
-        return distance(from: startIndex, to: endIndex)
+        return base.distance(from: base.startIndex, to: base.endIndex)
     }
 
     var dashesWithMatchingLength: String {
@@ -18,7 +18,7 @@ internal extension String {
     func withIndentedNewLines(prefix: String) -> String {
         var indentedString = ""
 
-        for (index, line) in components(separatedBy: .newlines).enumerated() {
+        for (index, line) in base.components(separatedBy: .newlines).enumerated() {
             let linePrefix = (index == 0 ? prefix : "\n   ")
             indentedString.append(linePrefix + line)
         }

--- a/Sources/MarathonCore/URL+Marathon.swift
+++ b/Sources/MarathonCore/URL+Marathon.swift
@@ -7,22 +7,22 @@
 import Foundation
 import Require
 
-internal extension URL {
+internal extension Marathon where Base == URL {
     var isForRemoteRepository: Bool {
-        return absoluteString.hasSuffix(".git")
+        return base.absoluteString.hasSuffix(".git")
     }
 
     var isForScript: Bool {
-        return absoluteString.hasSuffix(".swift")
+        return base.absoluteString.hasSuffix(".swift")
     }
 
     var parent: URL? {
-        guard let scheme = scheme else {
+        guard let scheme = base.scheme else {
             return nil
         }
 
         let schemeWithSuffix = scheme + "://"
-        let string = absoluteString
+        let string = base.absoluteString
 
         guard string != schemeWithSuffix else {
             return nil
@@ -46,7 +46,7 @@ internal extension URL {
             return nil
         }
 
-        let parentEndIndex = string.index(string.endIndex, offsetBy: -lastComponent.length)
+        let parentEndIndex = string.index(string.endIndex, offsetBy: -lastComponent.mt.length)
         let parentString = string.substring(to: parentEndIndex)
 
         guard parentString != schemeWithSuffix else {
@@ -55,25 +55,25 @@ internal extension URL {
 
         return URL(string: parentString).require()
     }
-    
+
     func transformIfNeeded() -> URL {
         guard isGitHubURL else {
-            return self
+            return base.self
         }
-        
-        return rawGitHubURL ?? self
+
+        return rawGitHubURL ?? base.self
     }
-    
+
     private var isGitHubURL: Bool {
-        return host == "github.com"
+        return base.host == "github.com"
     }
-    
+
     private var rawGitHubURL: URL? {
-        let base = "https://raw.githubusercontent.com"
-        
-        let urlString = pathComponents
+        let baseURLString = "https://raw.githubusercontent.com"
+
+        let urlString = base.pathComponents
             .filter { $0 != "blob" && $0 != "/" }
-            .reduce(base) { "\($0)/\($1)" }
+            .reduce(baseURLString) { "\($0)/\($1)" }
         
         return URL(string: urlString)
     }


### PR DESCRIPTION
Use `Marathon` proxy as customization point for constrained protocol
extensions. This change doesn't affect any `Marathon` function, so please introduce them if you like.

- Rename `Marathon` to `MarathonCore`. (There is no change in the original `Marathon.swift`.)
- Create `Marathon.swift` to use `Marathon` proxy as customization point for constrained protocol extensions.

The merits are
- Can provide clear extensions defined by `Marathon`.
- Can avoid extension's collisions.
- Looks a modern way.

Referred to the following libraries.
- https://github.com/ReactiveX/RxSwift/blob/master/RxSwift/Reactive.swift
- https://github.com/ReactiveCocoa/ReactiveSwift/blob/master/Sources/Reactive.swift
- https://github.com/Nirma/Attributed/blob/master/Attributed/Attributed.swift
