### PR TITLE
Parallelize tests on CI

### DIFF
--- a/buddybuild_postbuild.sh
+++ b/buddybuild_postbuild.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-swift test
+swift test --parallel


### PR DESCRIPTION
Use the `--parallel` flag when running `swift test`