### PR TITLE
Run Swift command line tools through xcrun

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+os: linux
+language: generic
+sudo: required
+dist: trusty
+install:
+    - curl -sL https://gist.github.com/kylef/5c0475ff02b7c7671d2a/raw/621ef9b29bbb852fdfd2e10ed147b321d792c1e4/swiftenv-install.sh | bash
+    - . ~/.swiftenv/init
+    - swiftenv install 3.1
+script:
+    - swift test

--- a/Sources/MarathonCore/PackageManager.swift
+++ b/Sources/MarathonCore/PackageManager.swift
@@ -288,7 +288,7 @@ internal final class PackageManager {
 
         do {
             try generateMasterPackageDescription()
-            try generatedFolder.moveToAndPerform(command: "swift package --enable-prefetching update", printer: printer)
+            try shellOutToSwiftCommand("package --enable-prefetching update", in: generatedFolder, printer: printer)
             try generatedFolder.createSubfolderIfNeeded(withName: "Packages")
         } catch {
             throw Error.failedToUpdatePackages(folder)

--- a/Sources/MarathonCore/Script.swift
+++ b/Sources/MarathonCore/Script.swift
@@ -80,8 +80,8 @@ internal final class Script {
 
     func build(withArguments arguments: [String] = []) throws {
         do {
-            let command = "swift build --enable-prefetching " + arguments.joined(separator: " ")
-            try folder.moveToAndPerform(command: command, printer: printer)
+            let command = "build -C \(folder.path) --enable-prefetching " + arguments.joined(separator: " ")
+            try shellOutToSwiftCommand(command, in: folder, printer: printer)
         } catch {
             throw formatBuildError(error as! ShellOutError)
         }
@@ -171,7 +171,7 @@ internal final class Script {
     }
 
     private func generateXcodeProject() throws -> Folder {
-        try folder.moveToAndPerform(command: "swift package generate-xcodeproj", printer: printer)
+        try shellOutToSwiftCommand("package generate-xcodeproj", in: folder, printer: printer)
         return try folder.subfolder(named: name + ".xcodeproj")
     }
 

--- a/Sources/MarathonCore/ScriptManager.swift
+++ b/Sources/MarathonCore/ScriptManager.swift
@@ -15,7 +15,7 @@ public enum ScriptManagerError {
     case failedToCreatePackageFile(Folder)
     case failedToAddDependencyScript(String)
     case failedToRemoveScriptFolder(Folder)
-    case failedToDownloadScript(URL)
+    case failedToDownloadScript(URL, Error)
 }
 
 extension ScriptManagerError: PrintableError {
@@ -29,8 +29,8 @@ extension ScriptManagerError: PrintableError {
             return "Failed to add the dependency script at '\(path)'"
         case .failedToRemoveScriptFolder(_):
             return "Failed to remove script folder"
-        case .failedToDownloadScript(let url):
-            return "Failed to download script from '\(url.absoluteString)'"
+        case .failedToDownloadScript(let url, let error):
+            return "Failed to download script from '\(url.absoluteString)' (\(error))"
         }
     }
 
@@ -111,7 +111,7 @@ internal final class ScriptManager {
 
             return try script(from: file)
         } catch {
-            throw Error.failedToDownloadScript(url)
+            throw Error.failedToDownloadScript(url, error)
         }
     }
 

--- a/Sources/MarathonCore/ShellOut+Marathon.swift
+++ b/Sources/MarathonCore/ShellOut+Marathon.swift
@@ -10,7 +10,7 @@ import ShellOut
 import Require
 
 @discardableResult internal func shellOut(to command: String,
-                                          in folder: Folder = FileSystem().currentFolder,
+                                          in folder: Folder = Folder.current,
                                           printer: Printer) throws -> String {
     do {
         printer.verboseOutput("$ cd \"\(folder.path)\" && \(command)")
@@ -29,4 +29,19 @@ import Require
 
         throw error
     }
+}
+
+@discardableResult internal func shellOutToSwiftCommand(_ command: String,
+                                                        in folder: Folder = Folder.current,
+                                                        printer: Printer) throws -> String {
+    func resolveSwiftPath() -> String {
+        #if os(Linux)
+        return "swift"
+        #else
+        return "/usr/bin/env xcrun --sdk macosx swift"
+        #endif
+    }
+
+    let swiftPath = resolveSwiftPath()
+    return try shellOut(to: "\(swiftPath) \(command)", in: folder, printer: printer)
 }

--- a/Tests/MarathonTests/MarathonTests.swift
+++ b/Tests/MarathonTests/MarathonTests.swift
@@ -35,20 +35,20 @@ class MarathonTests: XCTestCase {
     // MARK: - Managing packages
 
     func testAddingAndRemovingRemotePackage() throws {
-        try run(with: ["add", "git@github.com:JohnSundell/Files.git"])
+        try run(with: ["add", "https://github.com/JohnSundell/Files.git"])
         XCTAssertNotNil(try? folder.subfolder(named: "Packages").file(named: "Files").read())
 
         let generatedFolder = try folder.subfolder(atPath: "Packages/Generated")
 
         let packageFile = try generatedFolder.file(named: "Package.swift")
-        try XCTAssertTrue(packageFile.readAsString().contains("git@github.com:JohnSundell/Files.git"))
+        try XCTAssertTrue(packageFile.readAsString().contains("https://github.com/JohnSundell/Files.git"))
 
         let packagesFolder = try generatedFolder.subfolder(named: ".build/checkouts")
         XCTAssertEqual(packagesFolder.subfolders.count, 1)
         XCTAssertEqual(packagesFolder.subfolders.first?.name.hasPrefix("Files.git"), true)
 
         // List should now include the package
-        try XCTAssertTrue(run(with: ["list"]).contains("git@github.com:JohnSundell/Files.git"))
+        try XCTAssertTrue(run(with: ["list"]).contains("https://github.com/JohnSundell/Files.git"))
 
         // Remove the package
         try run(with: ["remove", "files"])
@@ -56,7 +56,7 @@ class MarathonTests: XCTestCase {
         try XCTAssertEqual(folder.subfolder(named: "Packages").files.count, 0)
 
         // List should no longer include the package
-        try XCTAssertFalse(run(with: ["list"]).contains("git@github.com:JohnSundell/Files.git"))
+        try XCTAssertFalse(run(with: ["list"]).contains("https://github.com/JohnSundell/Files.git"))
     }
 
     func testAddingAndRemovingLocalPackage() throws {
@@ -91,9 +91,9 @@ class MarathonTests: XCTestCase {
     }
 
     func testRemovingAllPackages() throws {
-        try run(with: ["add", "git@github.com:JohnSundell/Files.git"])
-        try run(with: ["add", "git@github.com:JohnSundell/Wrap.git"])
-        try run(with: ["add", "git@github.com:JohnSundell/Unbox.git"])
+        try run(with: ["add", "https://github.com/JohnSundell/Files.git"])
+        try run(with: ["add", "https://github.com/JohnSundell/Wrap.git"])
+        try run(with: ["add", "https://github.com/JohnSundell/Unbox.git"])
 
         let generatedFolder = try folder.subfolder(atPath: "Packages/Generated")
         let packagesFolder = try generatedFolder.subfolder(named: ".build/checkouts")
@@ -187,10 +187,10 @@ class MarathonTests: XCTestCase {
     }
 
     func testAddingAlreadyAddedPackageThrows() throws {
-        try run(with: ["add", "git@github.com:JohnSundell/Files.git"])
+        try run(with: ["add", "https://github.com/JohnSundell/Files.git"])
         XCTAssertNotNil(try? folder.subfolder(named: "Packages").file(named: "Files").read())
 
-        assert(try run(with: ["add", "git@github.com:JohnSundell/Files.git"]),
+        assert(try run(with: ["add", "https://github.com/JohnSundell/Files.git"]),
                throwsError: PackageManagerError.packageAlreadyAdded("Files"))
     }
 
@@ -206,7 +206,7 @@ class MarathonTests: XCTestCase {
         let scriptFile = try folder.createFile(named: "script.swift")
         try scriptFile.write(string: script)
 
-        try run(with: ["add", "git@github.com:JohnSundell/Files.git"])
+        try run(with: ["add", "https://github.com/JohnSundell/Files.git"])
         try run(with: ["run", scriptFile.path])
 
         XCTAssertNotNil(try? folder.subfolder(named: "addedFromScript"))
@@ -223,7 +223,7 @@ class MarathonTests: XCTestCase {
         try scriptFile.write(string: script)
 
         try run(with: ["run", scriptFile.path])
-        try run(with: ["add", "git@github.com:JohnSundell/Files.git"])
+        try run(with: ["add", "https://github.com/JohnSundell/Files.git"])
 
         script += "import Files\n\n" +
                   "try FileSystem().createFolder(at: filePath)"
@@ -310,7 +310,7 @@ class MarathonTests: XCTestCase {
     // MARK: - Installing scripts
 
     func testInstallingLocalScript() throws {
-        try run(with: ["add", "git@github.com:JohnSundell/Files.git"])
+        try run(with: ["add", "https://github.com/JohnSundell/Files.git"])
 
         let script = "import Files\n\n" +
                      "print(FileSystem().currentFolder.path)"
@@ -518,7 +518,7 @@ class MarathonTests: XCTestCase {
 
     func testUsingMarathonfileToInstallDependencies() throws {
         // Add Files before, since already installed dependencies should be ignored
-        try run(with: ["add", "git@github.com:JohnSundell/Files.git"])
+        try run(with: ["add", "https://github.com/JohnSundell/Files.git"])
 
         let script = "import Foundation\n" +
                      "import Files\n" +
@@ -530,8 +530,8 @@ class MarathonTests: XCTestCase {
         let scriptFile = try folder.createFile(named: "script.swift")
         try scriptFile.write(string: script)
 
-        let marathonFileContent = "git@github.com:JohnSundell/Files.git\n" +
-                                  "git@github.com:JohnSundell/Wrap.git"
+        let marathonFileContent = "https://github.com/JohnSundell/Files.git\n" +
+                                  "https://github.com/JohnSundell/Wrap.git"
 
         let marathonFile = try folder.createFile(named: "Marathonfile")
         try marathonFile.write(string: marathonFileContent)

--- a/Tests/MarathonTests/MarathonTests.swift
+++ b/Tests/MarathonTests/MarathonTests.swift
@@ -577,7 +577,7 @@ class MarathonTests: XCTestCase {
 
         // Verify build folder structure
         let buildFolder = try folder.subfolder(atPath: "Scripts/Cache").subfolders.first.require().subfolder(named: "Sources")
-        XCTAssertEqual(buildFolder.files.names, ["dependency.swift", "main.swift"])
+        XCTAssertEqual(buildFolder.files.names.sorted(), ["dependency.swift", "main.swift"])
 
         // Scripts removed from the Marathonfile should also be removed from the build folder
         try marathonFile.write(string: "")

--- a/Tests/MarathonTests/MarathonTests.swift
+++ b/Tests/MarathonTests/MarathonTests.swift
@@ -638,6 +638,21 @@ class MarathonTests: XCTestCase {
             }
         }
     }
+
+    func testNoDirectUsesOfSwiftCommandLineToolOnMacOS() throws {
+        for file in try resolveSourceFiles() {
+            XCTAssertEqual(file.extension, "swift")
+
+            let source = try file.readAsString()
+
+            // No files should shell out directly to 'swift ...' on macOS, 'xcrun' should always be used
+            XCTAssertFalse(source.contains("shellOut(to: \"swift"),
+                           "\(file.name) shells out to swift directly, use shellOutToSwiftCommand() instead")
+
+            XCTAssertFalse(source.contains("moveToAndPerform(command: \"swift"),
+                           "\(file.name) shells out to swift directly, use shellOutToSwiftCommand() instead")
+        }
+    }
 }
 
 // MARK: - Utilities

--- a/Tests/MarathonTests/MarathonTests.swift
+++ b/Tests/MarathonTests/MarathonTests.swift
@@ -51,7 +51,7 @@ class MarathonTests: XCTestCase {
         try XCTAssertTrue(run(with: ["list"]).contains("https://github.com/JohnSundell/Files.git"))
 
         // Remove the package
-        try run(with: ["remove", "files"])
+        try run(with: ["remove", "Files"])
         XCTAssertEqual(packagesFolder.subfolders.count, 0)
         try XCTAssertEqual(folder.subfolder(named: "Packages").files.count, 0)
 


### PR DESCRIPTION
With this change, the Swift command line tools and compiler are always invoked using xcrun on macOS, with explicit SDK settings. This enables Marathon to be run from within another xcodebuild process (such as a “run script phase” in Xcode).

So you can now write build scripts in Swift! 🎉 