### PR TITLE
ScriptManager: Add support for inline dependency resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ $ marathon run helloWorld
 
 📦 Hassle free dependency management. Simply add a package...
 ```
-$ marathon add git@github.com:JohnSundell/Files.git
+$ marathon add https://github.com/JohnSundell/Files.git
 ```
 
 ...and use it without any additional work
@@ -76,10 +76,16 @@ $ addSuffix "@2x"
 > Added suffix "@2x" to 15 files
 ```
 
-👪 Share your scripts with your team and automatically install their dependencies:
+👪 Share your scripts with your team and automatically install their dependencies...
+```swift
+import Files // marathon:https://github.com/JohnSundell/Files.git
+
+print(Folder.current.path)
 ```
-$ echo "git@github.com:JohnSundell/Files.git" > Marathonfile
-$ marathon run mySharedScript
+
+...or specify your dependencies using a `Marathonfile`:
+```
+$ echo "https://github.com/JohnSundell/Files.git" > Marathonfile
 ```
 
 ## Installing
@@ -125,14 +131,23 @@ Marathon requires the following to be installed on your system:
 
 Check out [this repository](https://github.com/JohnSundell/Marathon-Examples) for a few example Swift scripts that you can run using Marathon.
 
+## Specifying dependencies inline
+
+Scripting usually involves using 3rd party frameworks to get your job done, and Marathon provides an easy way to define such dependencies right when you are importing them in your script, using a simple comment syntax:
+
+```swift
+import Files // marathon:https://github.com/JohnSundell/Files.git
+import Unbox // marathon:https://github.com/JohnSundell/Unbox.git
+```
+
+Specifying your dependencies ensures that they will always be installed by Marathon before your script is run, edited or installed - making it super easy to share scripts with your friends, team or the wider community. All you have to do is share the script file, and Marathon takes care of the rest!
+
 ## Using a Marathonfile
 
-To easily define dependencies for a script in a declarative way, you can create a `Marathonfile` in the same folder as your script. This file is simply a *new line separated list* of URLs pointing to either:
+If you prefer to keep your dependency declarations separate, you can create a `Marathonfile` in the same folder as your script. This file is simply a *new line separated list* of URLs pointing to either:
 
 - The URL to a git repository of a local or remote package to install before running your script.
 - The path to another script that should be linked to your script before running it.
-
- By using a `Marathonfile` you can ensure that the required dependencies will be installed when sharing your script with team members, friends or the wider community.
 
 Here is an example of a `Marathonfile`:
 ```

--- a/Tests/MarathonTests/MarathonTests.swift
+++ b/Tests/MarathonTests/MarathonTests.swift
@@ -599,6 +599,21 @@ class MarathonTests: XCTestCase {
                throwsError: MarathonFileError.failedToRead(marathonFile))
     }
 
+    // MARK: - Inline dependency resolution
+
+    func testResolvingInlineDependencies() throws {
+        let script = "import Foundation\n" +
+                     "import Files // marathon:https://github.com/JohnSundell/Files.git\n\n" +
+                     "import Unbox //marathon: https://github.com/JohnSundell/Unbox.git\n\n" +
+                     "print(Folder.current.path)"
+
+        let scriptFile = try folder.createFile(named: "script.swift")
+        try scriptFile.write(string: script)
+
+        let output = try run(with: ["run", scriptFile.path])
+        XCTAssertEqual(output, folder.path)
+    }
+
     // MARK: - Source verification
 
     func testNoDirectUsesOfPrintFunction() throws {

--- a/Tests/MarathonTests/MarathonTests.swift
+++ b/Tests/MarathonTests/MarathonTests.swift
@@ -674,15 +674,13 @@ class MarathonTests: XCTestCase {
 
 fileprivate extension MarathonTests {
     func createFolder() -> Folder {
-        let parentFolder = try! Folder.home.createSubfolderIfNeeded(withName: ".marathonTests")
+        let parentFolder = (try? Folder.home.createSubfolderIfNeeded(withName: ".marathonTests"))
+                               .require(hint: "Could not set up '.marathonTests' root folder")
+
         let folderName = UUID().uuidString
-
-        if let existingFolder = try? parentFolder.subfolder(named: folderName) {
-            try! existingFolder.empty(includeHidden: true)
-            return existingFolder
-        }
-
-        return try! parentFolder.createSubfolder(named: folderName)
+        let folder = (try? parentFolder.createSubfolderIfNeeded(withName: folderName)).require(hint: "Could not setup child test folder")
+        try! folder.empty(includeHidden: true)
+        return folder
     }
 
     @discardableResult func run(with arguments: [String]) throws -> String {

--- a/Tests/MarathonTests/MarathonTests.swift
+++ b/Tests/MarathonTests/MarathonTests.swift
@@ -605,7 +605,8 @@ class MarathonTests: XCTestCase {
         let script = "import Foundation\n" +
                      "import Files // marathon:https://github.com/JohnSundell/Files.git\n\n" +
                      "import Unbox //marathon: https://github.com/JohnSundell/Unbox.git\n\n" +
-                     "print(Folder.current.path)"
+                     "print(Folder.current.path)\n" +
+                     "struct Model: Unboxable { init(unboxer: Unboxer) throws {} }"
 
         let scriptFile = try folder.createFile(named: "script.swift")
         try scriptFile.write(string: script)


### PR DESCRIPTION
This change adds support for specifying dependencies inline, instead of having to use a Marathonfile. A comment can now simply be added next to an `import` statement, specifying the URL that the dependency can be found at, and Marathon will automatically add that dependency, just like when a Marathonfile is used.

The implementation is a bit naive, as it simply splits the script file based on new lines and iterates through them (although an optimization has been made to stop as soon as a non-import alphanumeric character is found). A more optimized solution would probably be to stream the file and keep reading bytes until all imports have been parsed.

Resolves https://github.com/JohnSundell/Marathon/issues/34