### PR TITLE
Inline dependency resolution: Ignore already added dependencies

### DIFF
--- a/Sources/MarathonCore/PackageManager.swift
+++ b/Sources/MarathonCore/PackageManager.swift
@@ -116,12 +116,12 @@ internal final class PackageManager {
         return package
     }
 
-    func addPackages(fromMarathonFile file: MarathonFile) throws {
+    func addPackagesIfNeeded(from packageURLs: [URL]) throws {
         let existingPackageURLs = Set(makePackageList().map { package in
             return package.url
         })
 
-        for url in file.packageURLs {
+        for url in packageURLs {
             guard !existingPackageURLs.contains(url) else {
                 continue
             }


### PR DESCRIPTION
Just like when adding dependencies using a Marathonfile, the inline dependency resolver now also ignores already added packages. This is done by using the same code path for both inline and Marathonfile-based dependency resolution.