### PR TITLE
Add support for zsh autocomplete

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,16 @@ git@github.com:JohnSundell/Wrap.git
 otherScript.swift
 ```
 
+## Shell autocomplete
+
+Marathon includes autocomplete for the `zsh` shell (PRs adding support for other shells is more than welcome!). To enable it, do the following:
+
+- Add the line `fpath=(~/.marathon/zsh $fpath)` to your `~/.zshrc` file.
+- Add the line `autoload -Uz compinit && compinit -i` to your `~/.zshrc` file if it doesn't already contain it.
+- Restart your terminal.
+
+You can now type `marathon r` and have it be autocompleted to `marathon run` 🎉
+
 ## Help, feedback or suggestions?
 
 - Run `$ marathon help` to display help for the tool itself or for any specific command.

--- a/Sources/MarathonCore/Marathon.swift
+++ b/Sources/MarathonCore/Marathon.swift
@@ -41,6 +41,8 @@ public final class Marathon {
             let packageFolder = try rootFolder.createSubfolderIfNeeded(withName: "Packages")
             let scriptFolder = try rootFolder.createSubfolderIfNeeded(withName: "Scripts")
 
+            installShellAutocompleteIfNeeded(in: rootFolder)
+
             let packageManager = try PackageManager(folder: packageFolder, printer: printer)
             let scriptManager = try ScriptManager(folder: scriptFolder, packageManager: packageManager, printer: printer)
 
@@ -97,5 +99,9 @@ public final class Marathon {
             let message = "\u{001B}[0;3m\(messageExpression())\u{001B}[0;23m"
             progressFunction(message)
         }
+    }
+
+    private static func installShellAutocompleteIfNeeded(in folder: Folder) {
+        ZshAutocompleteInstaller.installIfNeeded(in: folder)
     }
 }

--- a/Sources/MarathonCore/ZshAutocompleteInstaller.swift
+++ b/Sources/MarathonCore/ZshAutocompleteInstaller.swift
@@ -1,0 +1,38 @@
+/**
+ *  Marathon
+ *  Copyright (c) John Sundell 2017
+ *  Licensed under the MIT license. See LICENSE file.
+ */
+
+import Foundation
+import Files
+
+internal final class ZshAutocompleteInstaller {
+    static func installIfNeeded(in folder: Folder) {
+        do {
+            guard !folder.containsSubfolder(named: "zsh") else {
+                return
+            }
+
+            let zshFolder = try folder.createSubfolder(named: "zsh")
+            let autocompleteFile = try zshFolder.createFile(named: "_marathon")
+
+            var autocompleteCode = "#compdef marathon\n\n"
+            autocompleteCode.append("local -a commands\n\n")
+            autocompleteCode.append("commands=(")
+
+            for command in Command.all {
+                autocompleteCode.append("\n    \"\(command.rawValue):\(command.description)\"")
+            }
+
+            autocompleteCode.append("\n)\n\n")
+            autocompleteCode.append("_arguments \\\n")
+            autocompleteCode.append("    \"1: :{_describe 'command' commands}\" \\\n")
+            autocompleteCode.append("    \"*: filename:_files\"")
+
+            try autocompleteFile.write(string: autocompleteCode)
+        } catch {
+            // Since this operation isn't critical, we silently fail if an error occur
+        }
+    }
+}


### PR DESCRIPTION
This change makes Marathon support zsh’s autocomplete functionality. This is done by creating a autocomplete function file in `~/.marathon/zsh/_marathon`. The user then needs to add this folder to the system’s `$fpath`. Instructions how to do this have been added to the README.