### PR TITLE
PackageManager: Don’t re-add already added packages with differently cased URL

### DIFF
--- a/Sources/MarathonCore/PackageManager.swift
+++ b/Sources/MarathonCore/PackageManager.swift
@@ -118,11 +118,11 @@ internal final class PackageManager {
 
     func addPackagesIfNeeded(from packageURLs: [URL]) throws {
         let existingPackageURLs = Set(makePackageList().map { package in
-            return package.url
+            return package.url.absoluteString.lowercased()
         })
 
         for url in packageURLs {
-            guard !existingPackageURLs.contains(url) else {
+            guard !existingPackageURLs.contains(url.absoluteString.lowercased()) else {
                 continue
             }
 


### PR DESCRIPTION
This patch fixes a bug that would cause a package to be re-added to Marathon when the given URL had a different casing than the one already added. So, if first Files is added using `https://github.com/JohnSundell/Files`, it would then be re-added if the URL `https://github.com/johnsundell/files` was given.