### PR TITLE
Run/Install: Enable referencing a remote script using a URL, repository or GitHub path

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,16 @@ $ marathon edit helloWorld
 $ marathon edit helloWorld --no-xcode
 ```
 
+🌍 Run remote scripts directly from a Git repository...
+```
+$ marathon run https://github.com/johnsundell/testdrive.git
+```
+
+...using only a GitHub username & repository name:
+```
+$ marathon run johnsundell/testdrive
+```
+
 💻 Install scripts as binaries and run them independently from anywhere...
 ```
 $ marathon install helloWorld
@@ -74,6 +84,12 @@ $ marathon install https://raw.githubusercontent.com/JohnSundell/Marathon-Exampl
 $ cd myImages
 $ addSuffix "@2x"
 > Added suffix "@2x" to 15 files
+```
+
+...or from a GitHub repository:
+```
+$ marathon install johnsundell/testdrive
+$ testdrive
 ```
 
 👪 Share your scripts with your team and automatically install their dependencies...

--- a/Sources/MarathonCore/Create.swift
+++ b/Sources/MarathonCore/Create.swift
@@ -40,7 +40,7 @@ internal final class CreateTask: Task, Executable {
     private typealias Error = CreateError
 
     func execute() throws {
-        guard let path = firstArgumentAsScriptPath else {
+        guard let path = arguments.first?.asScriptPath() else {
             throw Error.missingName
         }
 

--- a/Sources/MarathonCore/Edit.swift
+++ b/Sources/MarathonCore/Edit.swift
@@ -36,7 +36,7 @@ internal final class EditTask: Task, Executable {
     // MARK: - Executable
 
     func execute() throws {
-        guard let path = firstArgumentAsScriptPath else {
+        guard let path = arguments.first?.asScriptPath() else {
             throw Error.missingPath
         }
 

--- a/Sources/MarathonCore/Install.swift
+++ b/Sources/MarathonCore/Install.swift
@@ -34,11 +34,11 @@ internal class InstallTask: Task, Executable {
     private typealias Error = InstallError
 
     func execute() throws {
-        guard let path = firstArgumentAsScriptPath else {
+        guard let path = arguments.first else {
             throw Error.missingPath
         }
 
-        let script = try loadScript(from: path)
+        let script = try scriptManager.script(at: path)
         let installPath = makeInstallPath(for: script)
 
         printer.reportProgress("Compiling script...")
@@ -55,18 +55,6 @@ internal class InstallTask: Task, Executable {
         }
 
         printer.output("💻  \(path) installed at \(installPath)")
-    }
-
-    private func loadScript(from path: String) throws -> Script {
-        if let url = URL(string: path) {
-            if let urlScheme = url.scheme {
-                if urlScheme.hasPrefix("http") {
-                    return try scriptManager.downloadScript(from: url)
-                }
-            }
-        }
-
-        return try scriptManager.script(at: path)
     }
 
     private func makeInstallPath(for script: Script) -> String {

--- a/Sources/MarathonCore/Run.swift
+++ b/Sources/MarathonCore/Run.swift
@@ -43,7 +43,7 @@ internal class RunTask: Task, Executable {
     // MARK: - Executable
 
     func execute() throws {
-        guard let path = firstArgumentAsScriptPath else {
+        guard let path = arguments.first else {
             throw Error.missingPath
         }
 

--- a/Sources/MarathonCore/String+Marathon.swift
+++ b/Sources/MarathonCore/String+Marathon.swift
@@ -25,4 +25,14 @@ internal extension String {
 
         return indentedString
     }
+
+    func asScriptPath() -> String {
+        let suffix = ".swift"
+
+        guard hasSuffix(suffix) else {
+            return self + suffix
+        }
+
+        return self
+    }
 }

--- a/Sources/MarathonCore/Task.swift
+++ b/Sources/MarathonCore/Task.swift
@@ -28,18 +28,6 @@ internal class Task {
 }
 
 extension Task {
-    var firstArgumentAsScriptPath: String? {
-        guard let argument = arguments.first else {
-            return nil
-        }
-
-        guard argument.hasSuffix(".swift") else {
-            return argument + ".swift"
-        }
-
-        return argument
-    }
-
     var argumentsContainNoOpenFlag: Bool {
         return arguments.contains("--no-open")
     }

--- a/Tests/MarathonTests/MarathonTests.swift
+++ b/Tests/MarathonTests/MarathonTests.swift
@@ -311,6 +311,17 @@ class MarathonTests: XCTestCase {
         XCTAssertTrue(output.contains("🏃"))
     }
 
+    func testRunningRemoteScriptFromURL() throws {
+        let testDriveURL = "https://raw.githubusercontent.com/JohnSundell/TestDrive/master/Sources/TestDrive.swift"
+        let output = try run(with: ["run", testDriveURL])
+        XCTAssertTrue(output.hasPrefix("🚘"))
+    }
+
+    func testRunningRemoteScriptFromGitHubRepository() throws {
+        let output = try run(with: ["run", "johnsundell/testdrive"])
+        XCTAssertTrue(output.hasPrefix("🚘"))
+    }
+
     // MARK: - Installing scripts
 
     func testInstallingLocalScript() throws {


### PR DESCRIPTION
This change makes `run` able to run a remote script from a URL, a git repository URL or a GitHub path. For example, in order to run Test Drive users can now use either of these three methods to run it directly, without having to install it first:

- `marathon run https://github.com/johnsundell/testdrive.git`
- `marathon run https://raw.githubusercontent.com/JohnSundell/TestDrive/master/Sources/TestDrive.swift`
- `marathon run johnsundell/testdrive`

The latter is the big improvement, that enables running remote scripts using a very concise syntax.