### PR TITLE
Index nested dependency packages

### DIFF
--- a/Sources/MarathonCore/Package.swift
+++ b/Sources/MarathonCore/Package.swift
@@ -6,6 +6,7 @@
 
 import Foundation
 import Unbox
+import Releases
 
 public struct Package {
     public let name: String
@@ -38,5 +39,21 @@ internal extension Package {
         }
 
         return "\(name)-"
+    }
+}
+
+internal extension Package {
+    struct Pinned {
+        let name: String
+        let url: URL
+        let version: Version
+    }
+}
+
+extension Package.Pinned: Unboxable {
+    init(unboxer: Unboxer) throws {
+        name = try unboxer.unbox(key: "package")
+        url = try unboxer.unbox(key: "repositoryURL")
+        version = try unboxer.unbox(key: "version")
     }
 }

--- a/Sources/MarathonCore/Version+Marathon.swift
+++ b/Sources/MarathonCore/Version+Marathon.swift
@@ -1,0 +1,17 @@
+/**
+ *  Marathon
+ *  Copyright (c) John Sundell 2017
+ *  Licensed under the MIT license. See LICENSE file.
+ */
+
+import Foundation
+import Releases
+import Unbox
+
+extension Version: UnboxableByTransform {
+    public typealias UnboxRawValue = String
+
+    public static func transform(unboxedValue: String) -> Version? {
+        return try? Version(string: unboxedValue)
+    }
+}

--- a/Tests/MarathonTests/MarathonTests.swift
+++ b/Tests/MarathonTests/MarathonTests.swift
@@ -198,6 +198,16 @@ class MarathonTests: XCTestCase {
                throwsError: PackageManagerError.packageAlreadyAdded("Files"))
     }
 
+    func testTreatingNestedDependenciesAsAdded() throws {
+        // Xgen depends on Files
+        try run(with: ["add", "https://github.com/JohnSundell/Xgen.git"])
+
+        // Make sure both Xgen & Files are indexed by running 'list'
+        let listOutput = try run(with: ["list"])
+        XCTAssertTrue(listOutput.contains("Xgen (https://github.com/JohnSundell/Xgen.git)"))
+        XCTAssertTrue(listOutput.contains("Files (https://github.com/JohnSundell/Files.git)"))
+    }
+
     // MARK: - Running scripts
 
     func testRunningScriptWithoutPathThrows() {


### PR DESCRIPTION
With this change, Marathon now shows packages added as dependencies for other packages when running `list`. This has the added benefit of de- duplicating packages and avoiding running into collisions when adding a package which has already been added through another one’s dependency.

For example, adding Xgen (which has Files as a dependency) now also makes Files show up when running `marathon list`.