### PR TITLE
Improve error message when a script was not found

### DIFF
--- a/Sources/MarathonCore/Create.swift
+++ b/Sources/MarathonCore/Create.swift
@@ -54,7 +54,7 @@ internal final class CreateTask: Task, Executable {
         printer.output("🐣  Created script at \(path)")
 
         if !argumentsContainNoOpenFlag {
-            let script = try scriptManager.script(at: file.path)
+            let script = try scriptManager.script(at: file.path, allowRemote: false)
             try script.edit(arguments: arguments, open: true)
         }
     }

--- a/Sources/MarathonCore/Edit.swift
+++ b/Sources/MarathonCore/Edit.swift
@@ -40,7 +40,7 @@ internal final class EditTask: Task, Executable {
             throw Error.missingPath
         }
 
-        let script = try scriptManager.script(at: path)
+        let script = try scriptManager.script(at: path, allowRemote: false)
         try script.edit(arguments: arguments, open: !argumentsContainNoOpenFlag)
     }
 }

--- a/Sources/MarathonCore/Install.swift
+++ b/Sources/MarathonCore/Install.swift
@@ -38,7 +38,7 @@ internal class InstallTask: Task, Executable {
             throw Error.missingPath
         }
 
-        let script = try scriptManager.script(at: path)
+        let script = try scriptManager.script(at: path, allowRemote: true)
         let installPath = makeInstallPath(for: script)
 
         printer.reportProgress("Compiling script...")

--- a/Sources/MarathonCore/Run.swift
+++ b/Sources/MarathonCore/Run.swift
@@ -47,7 +47,7 @@ internal class RunTask: Task, Executable {
             throw Error.missingPath
         }
 
-        let script = try scriptManager.script(at: path)
+        let script = try scriptManager.script(at: path, allowRemote: true)
         try script.build()
 
         do {

--- a/Tests/MarathonTests/MarathonTests.swift
+++ b/Tests/MarathonTests/MarathonTests.swift
@@ -444,6 +444,18 @@ class MarathonTests: XCTestCase {
         XCTAssertNil(try? scriptFolders.first.require().subfolder(named: "Script.xcodeproj"))
     }
 
+    func testEditingMissingLocalScriptThrowsProperError() {
+        assert(try run(with: ["edit", "NotAScript"]),
+               throwsError: ScriptManagerError.scriptNotFound("NotAScript.swift"))
+    }
+
+    func testEditingRemoteScriptThrowsError() {
+        let testDriveURL = "https://raw.githubusercontent.com/JohnSundell/TestDrive/master/Sources/TestDrive.swift"
+
+        assert(try run(with: ["edit", testDriveURL]),
+               throwsError: ScriptManagerError.remoteScriptNotAllowed)
+    }
+
     // MARK: - Removing script data
 
     func testRemovingScriptCacheData() throws {
@@ -810,6 +822,8 @@ extension MarathonTests {
             ("testCreatingAndRunningScriptInFolderWithSpaces", testCreatingAndRunningScriptInFolderWithSpaces),
             ("testEditingScriptWithoutPathThrows", testEditingScriptWithoutPathThrows),
             ("testEditingScriptWithoutXcode", testEditingScriptWithoutXcode),
+            ("testEditingMissingLocalScriptThrowsProperError", testEditingMissingLocalScriptThrowsProperError),
+            ("testEditingRemoteScriptThrowsError", testEditingRemoteScriptThrowsError),
             ("testRemovingScriptCacheData", testRemovingScriptCacheData),
             ("testRemovingScriptCacheDataForDeletedScript", testRemovingScriptCacheDataForDeletedScript),
             ("testRemovingAllScriptData", testRemovingAllScriptData),


### PR DESCRIPTION
Previously, running “edit” or “run” with a missing script path would cause Marathon to start looking for a remote script. With this patch, remote scripts are only looked up for the “run” and “install” commands (since you can’t create or edit a remote script), and the error messages have been improved to include better actionable information if a script is missing.

For example, running `marathon edit NotAScript` will now give you the following error:
```
💥  Could not find a Swift script at 'NotAScript.swift'
👉  You can create a script at the given path by running 'marathon create NotAScript.swift'
```

Resolves https://github.com/JohnSundell/Marathon/issues/94