### PR TITLE
Create: Edit existing script instead of overwriting it

### DIFF
--- a/Sources/MarathonCore/Create.swift
+++ b/Sources/MarathonCore/Create.swift
@@ -44,6 +44,18 @@ internal final class CreateTask: Task, Executable {
             throw Error.missingName
         }
 
+        guard (try? File(path: path)) == nil else {
+            let editTask = EditTask(
+                folder: folder,
+                arguments: arguments,
+                scriptManager: scriptManager,
+                packageManager: packageManager,
+                printer: printer
+            )
+
+            return try editTask.execute()
+        }
+
         guard let data = makeScriptContent().data(using: .utf8) else {
             throw Error.failedToCreateFile(path)
         }

--- a/Tests/MarathonTests/MarathonTests.swift
+++ b/Tests/MarathonTests/MarathonTests.swift
@@ -414,6 +414,17 @@ class MarathonTests: XCTestCase {
         try run(with: ["run", "script"])
     }
 
+    func testCreatingScriptWithExistingPathRunsEditInstead() throws {
+        let scriptFolder = try folder.createSubfolder(named: "testScript")
+        let script = "import Foundation\nprint(\"I'm a script!\")"
+        let scriptFile = try scriptFolder.createFile(named: "Script.swift")
+        try scriptFile.write(string: script)
+
+        // Running create on the script should edit it instead of overwriting it
+        try run(with: ["create", scriptFile.path, "--no-open"])
+        XCTAssertEqual(try scriptFile.readAsString(), script)
+    }
+
     // MARK: - Editing scripts
 
     func testEditingScriptWithoutPathThrows() {
@@ -820,6 +831,7 @@ extension MarathonTests {
             ("testCreatingScriptWithPath", testCreatingScriptWithPath),
             ("testCreatingScriptWithContent", testCreatingScriptWithContent),
             ("testCreatingAndRunningScriptInFolderWithSpaces", testCreatingAndRunningScriptInFolderWithSpaces),
+            ("testCreatingScriptWithExistingPathRunsEditInstead", testCreatingScriptWithExistingPathRunsEditInstead),
             ("testEditingScriptWithoutPathThrows", testEditingScriptWithoutPathThrows),
             ("testEditingScriptWithoutXcode", testEditingScriptWithoutXcode),
             ("testEditingMissingLocalScriptThrowsProperError", testEditingMissingLocalScriptThrowsProperError),


### PR DESCRIPTION
Currently, if the user runs `marathon create MyScript.swift` when `MyScript.swift` already exists, it will be overwritten. Now, it instead opens the script in editing mode.