### PR TITLE
Support Swift 3.2 + 4.0 toolchains

### DIFF
--- a/Sources/MarathonCore/Package.swift
+++ b/Sources/MarathonCore/Package.swift
@@ -54,6 +54,11 @@ extension Package.Pinned: Unboxable {
     init(unboxer: Unboxer) throws {
         name = try unboxer.unbox(key: "package")
         url = try unboxer.unbox(key: "repositoryURL")
-        version = try unboxer.unbox(key: "version")
+
+        if let legacyVersion: Version = unboxer.unbox(key: "version") {
+            version = legacyVersion
+        } else {
+            version = try unboxer.unbox(keyPath: "state.version")
+        }
     }
 }

--- a/Sources/MarathonCore/ScriptManager.swift
+++ b/Sources/MarathonCore/ScriptManager.swift
@@ -307,7 +307,7 @@ internal final class ScriptManager {
     }
 
     private func makeManagedScriptPathList() -> [String] {
-        return cacheFolder.subfolders.flatMap { scriptFolder in
+        return cacheFolder.subfolders.flatMap { (scriptFolder) -> String? in
             guard let path = try? scriptFolder.moveToAndPerform(command: "readlink OriginalFile", printer: printer) else {
                 return nil
             }


### PR DESCRIPTION
It is now possible to work on Marathon using Xcode 9 and Swift 3.2 + 4.0 toolchains.