### PR TITLE
Make Swift Package Manager cache packages when using Xcode 9

### DIFF
--- a/Sources/MarathonCore/PackageManager.swift
+++ b/Sources/MarathonCore/PackageManager.swift
@@ -190,6 +190,18 @@ internal final class PackageManager {
                 try buildFolder.createSymlink(to: workspaceStateFile.path, at: "workspace-state.json", printer: printer)
             }
         }
+
+        if let dependenciesStateFile = try? generatedFolder.file(atPath: ".build/dependencies-state.json") {
+            if !buildFolder.containsFile(named: "dependencies-state.json") {
+                try buildFolder.createSymlink(to: dependenciesStateFile.path, at: "dependencies-state.json", printer: printer)
+            }
+        }
+
+        if let resolvedPackageFile = try? generatedFolder.file(named: "Package.resolved") {
+            if !folder.containsFile(named: "Package.resolved") {
+                try folder.createSymlink(to: resolvedPackageFile.path, at: "Package.resolved", printer: printer)
+            }
+        }
     }
 
     func updateAllPackagesToLatestMajorVersion() throws {


### PR DESCRIPTION
This patch prevents the Swift Package Manager from re-cloning and re-building all dependency packages for each script, thanks to some symlinking. We already use this technique for other files, but the Swift toolchain bundled with Xcode 9 includes two new files that need to be symlinked in order for SPM not to invalidate its state.