### PR TITLE
Support scripting using Swift 4

### DIFF
--- a/Sources/MarathonCore/Package.swift
+++ b/Sources/MarathonCore/Package.swift
@@ -29,16 +29,20 @@ extension Package: Unboxable {
 }
 
 internal extension Package {
-    var dependencyString: String {
-        return ".Package(url: \"\(url.absoluteString)\", majorVersion: \(majorVersion))"
-    }
-
     var folderPrefix: String {
         if url.isForRemoteRepository {
             return "\(name).git-"
         }
 
         return "\(name)-"
+    }
+
+    func dependencyString(forSwiftToolsVersion toolsVersion: Version) -> String {
+        if toolsVersion.major == 3 {
+            return ".Package(url: \"\(url.absoluteString)\", majorVersion: \(majorVersion))"
+        }
+
+        return ".package(url: \"\(url.absoluteString)\", from: \"\(majorVersion).0.0\")"
     }
 }
 

--- a/Sources/MarathonCore/Script.swift
+++ b/Sources/MarathonCore/Script.swift
@@ -67,6 +67,7 @@ internal final class Script {
 
     private let printer: Printer
     private var copyLoopDispatchQueue: DispatchQueue?
+    private var localPath: String { return "Sources/\(name)/main.swift"  }
 
     // MARK: - Init
 
@@ -197,7 +198,7 @@ internal final class Script {
     }
 
     private func copyChangesToSymlinkedFile() throws {
-        let data = try folder.file(atPath: "Sources/main.swift").read()
+        let data = try folder.file(atPath: localPath).read()
         try File(path: expandSymlink()).write(data: data)
     }
 
@@ -205,7 +206,7 @@ internal final class Script {
         var messages = [String]()
 
         for outputComponent in error.output.components(separatedBy: "\n") {
-            let lineComponents = outputComponent.components(separatedBy: folder.path + "Sources/main.swift:")
+            let lineComponents = outputComponent.components(separatedBy: folder.path + "\(localPath):")
 
             guard lineComponents.count > 1 else {
                 continue

--- a/Tests/MarathonTests/MarathonTests.swift
+++ b/Tests/MarathonTests/MarathonTests.swift
@@ -624,7 +624,7 @@ class MarathonTests: XCTestCase {
         XCTAssertEqual(try run(with: ["run", "TestScript/script"]), "Hello world")
 
         // Verify build folder structure
-        let buildFolder = try folder.subfolder(atPath: "Scripts/Cache").subfolders.first.require().subfolder(named: "Sources")
+        let buildFolder = try folder.subfolder(atPath: "Scripts/Cache").subfolders.first.require().subfolder(atPath: "Sources/script")
         XCTAssertEqual(buildFolder.files.names.sorted(), ["dependency.swift", "main.swift"])
 
         // Scripts removed from the Marathonfile should also be removed from the build folder


### PR DESCRIPTION
With this change Marathon supports writing scripts in Swift 4. If the user is using a Swift 4 toolchain, the language version will automatically be set to 4.0. Earlier toolchains will still use Swift 3.x.

The Swift 4 version of the Swift Package Manager requires a few more parameters to be specified in the package manifest, so this change mainly focuses on adding those, as well as adding a module folder (which is also required in Swift 4).

Backwards compatibility with Swift 3.1+ is still maintained.