### PR TITLE
Support script arguments containing a space

### DIFF
--- a/Sources/MarathonCore/Script.swift
+++ b/Sources/MarathonCore/Script.swift
@@ -90,7 +90,12 @@ internal final class Script {
 
     func run(in executionFolder: Folder, with arguments: [String]) throws -> String {
         let scriptPath = folder.path + ".build/debug/" + name
-        let command = scriptPath + " " + arguments.joined(separator: " ")
+        var command = scriptPath
+
+        if !arguments.isEmpty {
+            command += " \"" + arguments.joined(separator: "\" \"") + "\""
+        }
+
         return try executionFolder.moveToAndPerform(command: command, printer: printer)
     }
 

--- a/Tests/MarathonTests/MarathonTests.swift
+++ b/Tests/MarathonTests/MarathonTests.swift
@@ -332,6 +332,14 @@ class MarathonTests: XCTestCase {
         XCTAssertTrue(output.hasPrefix("🚘"))
     }
 
+    func testRunningScriptWithArgumentContainingSpace() throws {
+        let scriptFile = try folder.createFile(named: "script.swift")
+        try scriptFile.write(string: "print(CommandLine.arguments[1])")
+
+        let output = try run(with: ["run", scriptFile.path, "Hello world"])
+        XCTAssertEqual(output, "Hello world")
+    }
+
     // MARK: - Installing scripts
 
     func testInstallingLocalScript() throws {
@@ -830,6 +838,7 @@ extension MarathonTests {
             ("testRunningScriptWithVerboseOutput", testRunningScriptWithVerboseOutput),
             ("testRunningRemoteScriptFromURL", testRunningRemoteScriptFromURL),
             ("testRunningRemoteScriptFromGitHubRepository", testRunningRemoteScriptFromGitHubRepository),
+            ("testRunningScriptWithArgumentContainingSpace", testRunningScriptWithArgumentContainingSpace),
             ("testInstallingLocalScript", testInstallingLocalScript),
             ("testInstallingRemoteScriptWithDependenciesUsingRegularGithubURL", testInstallingRemoteScriptWithDependenciesUsingRegularGithubURL),
             ("testInstallingRemoteScriptWithDependenciesUsingRawGithubURL", testInstallingRemoteScriptWithDependenciesUsingRawGithubURL),


### PR DESCRIPTION
This patch fixes a bug that would cause arguments containing spaces to be split up into two arguments when passed to a script. The fix is to wrap all arguments in quotation marks to have them be correctly separated on the command line.

Resolves https://github.com/JohnSundell/Marathon/issues/114