### PR TITLE
Use --package-path instead of the deprecated -C flag.

### DIFF
--- a/Sources/MarathonCore/Script.swift
+++ b/Sources/MarathonCore/Script.swift
@@ -81,7 +81,7 @@ internal final class Script {
 
     func build(withArguments arguments: [String] = []) throws {
         do {
-            let command = "build -C \(folder.path) --enable-prefetching " + arguments.joined(separator: " ")
+            let command = "build --package-path \(folder.path) --enable-prefetching " + arguments.joined(separator: " ")
             try shellOutToSwiftCommand(command, in: folder, printer: printer)
         } catch {
             throw formatBuildError(error as! ShellOutError)


### PR DESCRIPTION
This fixes a build issue when using Marathon with Swift 4. 

This PR should probably wait here until Xcode 9 & Swift 4 is officially out.