### PR TITLE
[Homebrew] Support a build only command in the makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,12 @@
 INSTALL_PATH = /usr/local/bin/marathon
 
-install:
+install: build install_bin
+
+build:
 	swift package --enable-prefetching update
 	swift build --enable-prefetching -c release -Xswiftc -static-stdlib
+
+install_bin:
 	cp -f .build/release/Marathon $(INSTALL_PATH)
 
 uninstall:


### PR DESCRIPTION
To get homebrew support working I'd like to do something to SwiftFormat:

```ruby
def install
    system "make", "build"
    bin.install "build/Release/marathon"
end
```

which will allow homebrew to decide where to place the app - I figure the INSTALL_PATH should be doing this, but the step fails for me (only when running through homebrew)

![screen shot 2017-08-24 at 15 20 10](https://user-images.githubusercontent.com/49038/29684397-ceed8f8a-88df-11e7-8c5f-0622d473a509.png)
