### PR TITLE
Support running/installing remote Swift packages as scripts

### DIFF
--- a/Sources/MarathonCore/PackageManager.swift
+++ b/Sources/MarathonCore/PackageManager.swift
@@ -232,6 +232,29 @@ internal final class PackageManager {
         try updatePackages()
     }
 
+    func nameOfPackage(in folder: Folder) throws -> String {
+        let packageFile = try folder.file(named: "Package.swift")
+
+        for line in try packageFile.readAsString().components(separatedBy: .newlines) {
+            guard let nameTokenRange = line.range(of: "name:") else {
+                continue
+            }
+
+            var line = line.substring(from: nameTokenRange.upperBound)
+
+            if let range = line.range(of: ",") {
+                line = line.substring(to: range.lowerBound)
+            } else if let range = line.range(of: ")") {
+                line = line.substring(to: range.lowerBound)
+            }
+
+            line = line.trimmingCharacters(in: .whitespacesAndNewlines)
+            return line.replacingOccurrences(of: "\"", with: "")
+        }
+
+        throw Error.failedToReadPackageFile(packageFile.name)
+    }
+
     // MARK: - Private
 
     private func latestMajorVersionForPackage(at url: URL) throws -> Int {
@@ -258,29 +281,6 @@ internal final class PackageManager {
         } catch {
             throw Error.failedToResolveName(url)
         }
-    }
-
-    private func nameOfPackage(in folder: Folder) throws -> String {
-        let packageFile = try folder.file(named: "Package.swift")
-
-        for line in try packageFile.readAsString().components(separatedBy: .newlines) {
-            guard let nameTokenRange = line.range(of: "name:") else {
-                continue
-            }
-
-            var line = line.substring(from: nameTokenRange.upperBound)
-
-            if let range = line.range(of: ",") {
-                line = line.substring(to: range.lowerBound)
-            } else if let range = line.range(of: ")") {
-                line = line.substring(to: range.lowerBound)
-            }
-
-            line = line.trimmingCharacters(in: .whitespacesAndNewlines)
-            return line.replacingOccurrences(of: "\"", with: "")
-        }
-
-        throw Error.failedToReadPackageFile(packageFile.name)
     }
 
     private func nameOfRemotePackage(at url: URL) throws -> String {

--- a/Sources/MarathonCore/ScriptManager.swift
+++ b/Sources/MarathonCore/ScriptManager.swift
@@ -220,6 +220,14 @@ internal final class ScriptManager {
 
         let cloneFolder = try folder.subfolder(named: "clone")
 
+        if let packageName = try? packageManager.nameOfPackage(in: cloneFolder) {
+            let cloneFiles = cloneFolder.makeFileSequence(recursive: true)
+
+            if cloneFiles.contains(where: { $0.name == "main.swift" }) {
+                return Script(name: packageName, folder: cloneFolder, printer: printer)
+            }
+        }
+
         let swiftFiles = cloneFolder.makeFileSequence(recursive: true).filter { file in
             return file.extension == "swift" && file.nameExcludingExtension != "Package"
         }

--- a/Tests/MarathonTests/MarathonTests.swift
+++ b/Tests/MarathonTests/MarathonTests.swift
@@ -332,6 +332,11 @@ class MarathonTests: XCTestCase {
         XCTAssertTrue(output.hasPrefix("🚘"))
     }
 
+    func testRunningRemoteSwiftPackageAsScript() throws {
+        let output = try run(with: ["run", "johnsundell/marathon"])
+        XCTAssertTrue(output.hasPrefix("Welcome to Marathon"))
+    }
+
     func testRunningScriptWithArgumentContainingSpace() throws {
         let scriptFile = try folder.createFile(named: "script.swift")
         try scriptFile.write(string: "print(CommandLine.arguments[1])")
@@ -372,6 +377,15 @@ class MarathonTests: XCTestCase {
     func testInstallingRemoteScriptWithDependenciesUsingRawGithubURL() throws {
         let rawGitHubURLString = "https://raw.githubusercontent.com/JohnSundell/Marathon-Examples/master/AddSuffix/addSuffix.swift"
         try performTestForInstallingRemoteScriptWithDependenciesUsingURL(rawGitHubURLString)
+    }
+
+    func testInstallingRemoteSwiftPackageAsScript() throws {
+        // Install Marathon itself as a script
+        try run(with: ["install", "johnsundell/marathon", "installed-script"])
+
+        // Run the installed binary
+        let output = try folder.moveToAndPerform(command: "./installed-script")
+        XCTAssertTrue(output.hasPrefix("Welcome to Marathon"))
     }
 
     // MARK: - Creating scripts
@@ -838,10 +852,12 @@ extension MarathonTests {
             ("testRunningScriptWithVerboseOutput", testRunningScriptWithVerboseOutput),
             ("testRunningRemoteScriptFromURL", testRunningRemoteScriptFromURL),
             ("testRunningRemoteScriptFromGitHubRepository", testRunningRemoteScriptFromGitHubRepository),
+            ("testRunningRemoteSwiftPackageAsScript", testRunningRemoteSwiftPackageAsScript),
             ("testRunningScriptWithArgumentContainingSpace", testRunningScriptWithArgumentContainingSpace),
             ("testInstallingLocalScript", testInstallingLocalScript),
             ("testInstallingRemoteScriptWithDependenciesUsingRegularGithubURL", testInstallingRemoteScriptWithDependenciesUsingRegularGithubURL),
             ("testInstallingRemoteScriptWithDependenciesUsingRawGithubURL", testInstallingRemoteScriptWithDependenciesUsingRawGithubURL),
+            ("testInstallingRemoteSwiftPackageAsScript", testInstallingRemoteSwiftPackageAsScript),
             ("testCreatingScriptWithoutNameThrows", testCreatingScriptWithoutNameThrows),
             ("testCreatingScriptWithName", testCreatingScriptWithName),
             ("testCreatingScriptWithPath", testCreatingScriptWithPath),


### PR DESCRIPTION
This change makes it possible to have Marathon run and install remote executable Swift packages as scripts. Since what Marathon does under the hood is basically just to generate Swift packages for script files, all that needed to be done to support this new feature is to check if a downloaded repository is indeed a package, and then just use it directly.

To test that this works, Marathon remotely installs and runs itself, from its repo (so meta!)

Resolves https://github.com/JohnSundell/Marathon/issues/120