### PR TITLE
Add mint installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,11 @@ $ echo "https://github.com/JohnSundell/Files.git" > Marathonfile
 
 ### On macOS
 
+Using [Mint](https://github.com/yonaskolb/mint):
+```sh
+$ mint run JohnSundell/Marathon
+```
+
 Using Homebrew:
 ```sh
 brew install marathon-swift


### PR DESCRIPTION
This adds [Mint](https://github.com/yonaskolb/Mint) installation instructions to the readme 😄 