### PR TITLE
Ignore changes in shellout

### DIFF
--- a/Sources/MarathonCore/PackageManager.swift
+++ b/Sources/MarathonCore/PackageManager.swift
@@ -402,9 +402,9 @@ internal final class PackageManager {
     }
 
     private func resolveSwiftToolsVersion() throws -> Version {
-        var versionString = try shellOutToSwiftCommand("--version", printer: printer)
-        versionString = versionString.components(separatedBy: "(").first.require()
-        versionString = versionString.components(separatedBy: "version ").last.require()
+		var versionString = try shellOutToSwiftCommand("package --version", printer: printer)
+		versionString = versionString.replacingOccurrences(of: "Apple Swift Package Manager - Swift ", with: "")
+		versionString = versionString.components(separatedBy: "-").first.require()
 
         return try perform(Version(string: versionString),
                            orThrow: Error.failedToResolveSwiftToolsVersion)

--- a/Sources/MarathonCore/ShellOut+Marathon.swift
+++ b/Sources/MarathonCore/ShellOut+Marathon.swift
@@ -14,6 +14,9 @@ import Require
                                           printer: Printer) throws -> String {
     do {
         printer.verboseOutput("$ cd \"\(folder.path)\" && \(command)")
+		
+		// TRY NEXT: create a pipe for each shellOut.
+		
         let output = try shellOut(to: command, at: folder.path)
         printer.verboseOutput(output)
 


### PR DESCRIPTION
Ignore the changes in shellout+marathon; those are part of my ongoing project to get async output from Marathon.

The OTHER changes should handle the Xcode 9.1 package manager version bug.