### PR TITLE
CI: Don’t run tests in parallel

### DIFF
--- a/buddybuild_postbuild.sh
+++ b/buddybuild_postbuild.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-swift test --parallel
+swift test


### PR DESCRIPTION
An attempt to reduce flakiness by not parallelizing, until the tests can be reworked to not rely too much on internet connectivity.