### PR TITLE
Converts the edit function into separate pieces

### DIFF
--- a/Sources/MarathonCore/Create.swift
+++ b/Sources/MarathonCore/Create.swift
@@ -67,7 +67,8 @@ internal final class CreateTask: Task, Executable {
 
         if !argumentsContainNoOpenFlag {
             let script = try scriptManager.script(atPath: file.path, allowRemote: false)
-            try script.edit(arguments: arguments, open: true)
+            try script.setupForEdit(arguments: arguments)
+            try script.watch(arguments: arguments)
         }
     }
 

--- a/Sources/MarathonCore/Edit.swift
+++ b/Sources/MarathonCore/Edit.swift
@@ -41,6 +41,9 @@ internal final class EditTask: Task, Executable {
         }
 
         let script = try scriptManager.script(atPath: path, allowRemote: false)
-        try script.edit(arguments: arguments, open: !argumentsContainNoOpenFlag)
+        try script.setupForEdit(arguments: arguments)
+        if (!argumentsContainNoOpenFlag) {
+            try script.watch(arguments: arguments)
+        }
     }
 }

--- a/Sources/MarathonCore/Script.swift
+++ b/Sources/MarathonCore/Script.swift
@@ -166,14 +166,14 @@ internal final class Script {
     }
 
 
-    func resolveMarathonFile() throws -> MarathonFile? {
+    func resolveMarathonFile(fileName: String) throws -> MarathonFile? {
         let scriptFile = try File(path: expandSymlink())
 
         guard let parentFolder = scriptFile.parent else {
             return nil
         }
 
-        guard let file = try? parentFolder.file(named: "Marathonfile") else {
+        guard let file = try? parentFolder.file(named: fileName) else {
             return nil
         }
 

--- a/Sources/MarathonCore/Script.swift
+++ b/Sources/MarathonCore/Script.swift
@@ -16,6 +16,7 @@ import Require
 
 public enum ScriptError {
     case editingFailed(String)
+    case watchingFailed(String)
     case buildFailed([String], missingPackage: String?)
     case installFailed(String)
 }
@@ -29,6 +30,8 @@ extension ScriptError: PrintableError {
             return "Failed to compile script"
         case .installFailed(_):
             return "Failed to install script"
+        case .watchingFailed(let name):
+            return "Failed to start watcher for \(name)"
         }
     }
 
@@ -36,6 +39,8 @@ extension ScriptError: PrintableError {
         switch self {
         case .editingFailed(_):
             return ["Make sure that it exists and that its file is readable"]
+        case .watchingFailed(_):
+            return ["Check the error message for more information"]
         case .buildFailed(let errors, let missingPackage):
             guard !errors.isEmpty else {
                 return []
@@ -128,29 +133,38 @@ internal final class Script {
         }
     }
 
-    func edit(arguments: [String], open: Bool) throws {
+    @discardableResult
+    func setupForEdit(arguments: [String]) throws -> String {
         do {
-            let path = try editingPath(from: arguments)
-
-            if open {
-                let relativePath = path.replacingOccurrences(of: folder.path, with: "")
-                printer.output("✏️  Opening \(relativePath)")
-
-                try shellOut(to: "open \"\(path)\"", printer: printer)
-
-                if path.hasSuffix(".xcodeproj/") {
-                    printer.output("\nℹ️  Marathon will keep running, in order to commit any changes you make in Xcode back to the original script file")
-                    printer.output("   Press the return key once you're done")
-
-                    startCopyLoop()
-                    _ = FileHandle.standardInput.availableData
-                    try copyChangesToSymlinkedFile()
-                }
-            }
+            try generateXcodeProject()
+            return try editingPath(from: arguments)
         } catch {
             throw Error.editingFailed(name)
         }
     }
+
+    func watch(arguments: [String]) throws {
+        do {
+            let path = try editingPath(from: arguments)
+            let relativePath = path.replacingOccurrences(of: folder.path, with: "")
+            printer.output("✏️  Opening \(relativePath)")
+
+            try shellOut(to: "open \"\(path)\"", printer: printer)
+
+            if path.hasSuffix(".xcodeproj/") {
+                printer.output("\nℹ️  Marathon will keep running, in order to commit any changes you make in Xcode back to the original script file")
+                printer.output("   Press the return key once you're done")
+
+                startCopyLoop()
+                _ = FileHandle.standardInput.availableData
+                try copyChangesToSymlinkedFile()
+
+            }
+        } catch {
+            throw Error.watchingFailed(name)
+        }
+    }
+
 
     func resolveMarathonFile() throws -> MarathonFile? {
         let scriptFile = try File(path: expandSymlink())
@@ -173,12 +187,11 @@ internal final class Script {
             return try expandSymlink()
         }
 
-        return try generateXcodeProject().path
+        return try folder.subfolder(named: name + ".xcodeproj").path
     }
 
-    private func generateXcodeProject() throws -> Folder {
+    private func generateXcodeProject() throws {
         try shellOutToSwiftCommand("package generate-xcodeproj", in: folder, printer: printer)
-        return try folder.subfolder(named: name + ".xcodeproj")
     }
 
     private func expandSymlink() throws -> String {

--- a/Sources/MarathonCore/ScriptManager.swift
+++ b/Sources/MarathonCore/ScriptManager.swift
@@ -71,6 +71,17 @@ extension ScriptManagerError: PrintableError {
 // MARK: - ScriptManager
 
 internal final class ScriptManager {
+
+    internal struct Config {
+        let dependencyPrefix: String
+        let dependencyFile: String
+
+        init(prefix: String = "marathon:", file: String = "Marathonfile") {
+            dependencyPrefix = prefix
+            dependencyFile = file
+        }
+    }
+
     private typealias Error = ScriptManagerError
 
     var managedScriptPaths: [String] { return makeManagedScriptPathList() }
@@ -80,14 +91,16 @@ internal final class ScriptManager {
     private lazy var temporaryScriptFiles = [File]()
     private let packageManager: PackageManager
     private let printer: Printer
+    private let config: Config
 
     // MARK: - Lifecycle
 
-    init(folder: Folder, packageManager: PackageManager, printer: Printer) throws {
+    init(folder: Folder, packageManager: PackageManager, printer: Printer, config: Config = ScriptManager.Config()) throws {
         self.cacheFolder = try folder.createSubfolderIfNeeded(withName: "Cache")
         self.temporaryFolder = try folder.createSubfolderIfNeeded(withName: "Temp")
         self.packageManager = packageManager
         self.printer = printer
+        self.config = config
     }
 
     deinit {
@@ -158,7 +171,7 @@ internal final class ScriptManager {
         let folder = try createFolderIfNeededForScript(withIdentifier: identifier, file: file)
         let script = Script(name: file.nameExcludingExtension, folder: folder, printer: printer)
 
-        if let marathonFile = try script.resolveMarathonFile() {
+        if let marathonFile = try script.resolveMarathonFile(fileName: config.dependencyFile) {
             try packageManager.addPackagesIfNeeded(from: marathonFile.packageURLs)
             try addDependencyScripts(fromMarathonFile: marathonFile, for: script)
         }
@@ -189,13 +202,13 @@ internal final class ScriptManager {
             let file = try folder.createFile(named: fileName, contents: data)
             temporaryScriptFiles.append(file)
 
-            printer.reportProgress("Resolving Marathonfile...")
+            printer.reportProgress("Resolving \(config.dependencyFile)...")
             if let parentURL = url.parent {
-                let marathonFileURL = URL(string: parentURL.absoluteString + "Marathonfile").require()
+                let marathonFileURL = URL(string: parentURL.absoluteString + config.dependencyFile).require()
 
                 if let marathonFileData = try? Data(contentsOf: marathonFileURL) {
-                    printer.reportProgress("Saving Marathonfile...")
-                    try folder.createFile(named: "Marathonfile", contents: marathonFileData)
+                    printer.reportProgress("Saving \(config.dependencyFile)...")
+                    try folder.createFile(named: config.dependencyFile, contents: marathonFileData)
                 }
             }
 
@@ -252,6 +265,7 @@ internal final class ScriptManager {
         return identifier.components(separatedBy: "-").last.require().capitalized
     }
 
+
     private func createFolderIfNeededForScript(withIdentifier identifier: String, file: File) throws -> Folder {
         let scriptFolder = try cacheFolder.createSubfolderIfNeeded(withName: identifier)
         try packageManager.symlinkPackages(to: scriptFolder)
@@ -292,7 +306,7 @@ internal final class ScriptManager {
 
         for line in lines {
             if line.hasPrefix("import ") {
-                let components = line.components(separatedBy: "marathon:")
+                let components = line.components(separatedBy: config.dependencyPrefix)
 
                 guard components.count > 1 else {
                     continue


### PR DESCRIPTION
In Danger Swift, in order to use the edit function I must edit the Xcodeproject to add the runtime library  to the project. 

To do this: I need to separate out the work of "setup the xcodeproj" and "start the watcher" 

In doing so, I separated the generation of an xcodeproj from deriving the path of the project ( and offered it as an ignorable return value from the setup of an edit project )