### PR TITLE
Adds linkable library for all dependencies generated in a Marathon scripts

### DIFF
--- a/Sources/MarathonCore/PackageManager.swift
+++ b/Sources/MarathonCore/PackageManager.swift
@@ -364,7 +364,7 @@ public final class PackageManager {
                           "import PackageDescription\n\n" +
                           "let package = Package(\n" +
                           "    name: \"\(masterPackageName)\",\n" +
-                          "    products: [.library(name: \"Dependencies\", type: .dynamic, targets: [\"\(masterPackageName)\"])]," +
+                          "    products: [.library(name: \"Dependencies\", type: .dynamic, targets: [\"\(masterPackageName)\"])],\n" +
                           "    dependencies: [\n"
 
         for (index, package) in packages.enumerated() {

--- a/Sources/MarathonCore/PackageManager.swift
+++ b/Sources/MarathonCore/PackageManager.swift
@@ -364,7 +364,7 @@ public final class PackageManager {
                           "import PackageDescription\n\n" +
                           "let package = Package(\n" +
                           "    name: \"\(masterPackageName)\",\n" +
-                          "    products: [.library(name: \"Dependencies\", type: .dynamic, targets: [\"\(masterPackageName)\"])],\n" +
+                          "    products: [.library(name: \"MarathonDependencies\", type: .dynamic, targets: [\"\(masterPackageName)\"])],\n" +
                           "    dependencies: [\n"
 
         for (index, package) in packages.enumerated() {

--- a/Sources/MarathonCore/PackageManager.swift
+++ b/Sources/MarathonCore/PackageManager.swift
@@ -364,6 +364,7 @@ public final class PackageManager {
                           "import PackageDescription\n\n" +
                           "let package = Package(\n" +
                           "    name: \"\(masterPackageName)\",\n" +
+                          "    products: [.library(name: \"Dependencies\", type: .dynamic, targets: [\"\(masterPackageName)\"])]," +
                           "    dependencies: [\n"
 
         for (index, package) in packages.enumerated() {


### PR DESCRIPTION
This PR adds a a linkable library for the dependencies generated in Marathon scripts. tl;dr Danger uses Marathon to download its dependencies, but those deps need to be exposed to be linked against by Danger.

Paired on this with @orta. We used the name `Dependencies` for everything since it's pretty generic and captured all of the root-level dependencies. This will allow us to change this line:

https://github.com/danger/danger-swift/blob/5fd83392054054740cb4922a44fd4d59d2d6b05c/Sources/Runner/Commands/Runner.swift#L61

... to include `libArgs += ["-lDependencies"]` and expose Danger-Swift plugin symbols to `Dangerfile.swift` files. Let me know if I can clarify anything – thanks!