### PR TITLE
Use 'swift package --version' for swift-tools-version

### DIFF
--- a/Sources/MarathonCore/PackageManager.swift
+++ b/Sources/MarathonCore/PackageManager.swift
@@ -403,9 +403,9 @@ public final class PackageManager {
     }
 
     private func resolveSwiftToolsVersion() throws -> Version {
-        var versionString = try shellOutToSwiftCommand("--version", printer: printer)
-        versionString = versionString.components(separatedBy: "(").first.require()
-        versionString = versionString.components(separatedBy: "version ").last.require()
+        var versionString = try shellOutToSwiftCommand("package --version", printer: printer)
+        versionString = versionString.components(separatedBy: " (swiftpm").first.require()
+        versionString = versionString.components(separatedBy: "Swift Package Manager - Swift ").last.require()
 
         let versionComponents = versionString.components(separatedBy: ".")
 


### PR DESCRIPTION
Fix #137 #146 

I have the same problem to #146 .
This change made it to work well.
