### PR TITLE
Checks for ssh prefix to detect a repository

### DIFF
--- a/Sources/MarathonCore/ScriptManager.swift
+++ b/Sources/MarathonCore/ScriptManager.swift
@@ -117,7 +117,7 @@ public final class ScriptManager {
             return try script(from: file)
         }
 
-        if path.hasPrefix("http") || path.hasPrefix("git@") {
+        if path.hasPrefix("http") || path.hasPrefix("git@") || path.hasPrefix("ssh") {
             guard allowRemote else {
                 throw Error.remoteScriptNotAllowed
             }


### PR DESCRIPTION
Sometimes the `ssh://` scheme is used to allow cloning etc. from a git repo. (Bitbucket uses this for example)
This PR adds an additional check for this scheme.