### PR TITLE
Fix Swift 4.1 branch on Linux

### DIFF
--- a/Sources/MarathonCore/ScriptManager.swift
+++ b/Sources/MarathonCore/ScriptManager.swift
@@ -193,13 +193,14 @@ public final class ScriptManager {
             let url = url.transformIfNeeded()
 
             printer.reportProgress("Downloading script...")
-            let data = try Data(contentsOf: url)
-
-            printer.reportProgress("Saving script...")
             let identifier = scriptIdentifier(from: url.absoluteString)
             let folder = try temporaryFolder.createSubfolderIfNeeded(withName: identifier)
             let fileName = scriptName(from: identifier) + ".swift"
-            let file = try folder.createFile(named: fileName, contents: data)
+            let downloadCommand = "wget -O \"\(fileName)\" \"\(url)\""
+            try folder.moveToAndPerform(command: downloadCommand, printer: printer)
+
+            printer.reportProgress("Saving script...")
+            let file = try folder.file(named: fileName)
             temporaryScriptFiles.append(file)
 
             printer.reportProgress("Resolving \(config.dependencyFile)...")

--- a/Sources/MarathonCore/ScriptManager.swift
+++ b/Sources/MarathonCore/ScriptManager.swift
@@ -196,7 +196,7 @@ public final class ScriptManager {
             let identifier = scriptIdentifier(from: url.absoluteString)
             let folder = try temporaryFolder.createSubfolderIfNeeded(withName: identifier)
             let fileName = scriptName(from: identifier) + ".swift"
-            let downloadCommand = "wget -O \"\(fileName)\" \"\(url)\""
+            let downloadCommand = "wget -O \"\(fileName)\" \"\(url.absoluteString)\""
             try folder.moveToAndPerform(command: downloadCommand, printer: printer)
 
             printer.reportProgress("Saving script...")
@@ -207,10 +207,9 @@ public final class ScriptManager {
             if let parentURL = url.parent {
                 let marathonFileURL = URL(string: parentURL.absoluteString + config.dependencyFile).require()
 
-                if let marathonFileData = try? Data(contentsOf: marathonFileURL) {
-                    printer.reportProgress("Saving \(config.dependencyFile)...")
-                    try folder.createFile(named: config.dependencyFile, contents: marathonFileData)
-                }
+                printer.reportProgress("Saving \(config.dependencyFile)...")
+                let downloadCommand = "wget -O \"\(config.dependencyFile)\" \"\(marathonFileURL.absoluteString)\""
+                try folder.moveToAndPerform(command: downloadCommand, printer: printer)
             }
 
             return try script(from: file)


### PR DESCRIPTION
Hey! This should help in #161 with Linux tests.

You might think **"What better to do than spend the Friday night debugging Swift on Linux, eh?"**  -and you're absolutely right. I spent some time debugging the issue with Linux tests and I narrowed it down to one line. Try to run this line in your REPL:
```swift
NSData(contentsOfFile: "https://raw.githubusercontent.com/JohnSundell/MarathonTestScriptWithDependencies/master/Script.swift", options: .alwaysMapped)
```

And you should see something similar to:
<img width="1159" alt="zrzut ekranu 2018-04-21 o 01 59 34" src="https://user-images.githubusercontent.com/5232779/39078714-9bf6fb12-450d-11e8-8486-1c7425399d13.png">

So the problem is that for some reason we can't fetch the data from the interwebz using `Foundation` on Linux. The error suggests that the reason should be in [this file](https://github.com/apple/swift-corelibs-foundation/blob/master/Foundation/NSData.swift), possible in [this function](https://github.com/apple/swift-corelibs-foundation/blob/master/Foundation/NSData.swift#L401). I didn't really have time for a bigger investigation but probably radar or issue or (even a fix) should be filled. 

The solution, for now, is to use `wget -O fileName fileUrl`. I've checked both tests on macOS and Ubuntu 17~ and it looks good, but we'll see how the CI reacts 😄 

Let me know what do you think about this one ;-)