### PR TITLE
Bump Releases to 3.0.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/JohnSundell/Releases.git",
         "state": {
           "branch": null,
-          "revision": "0a3c1ba8ce8bb27c02c225979bfd02888b38f0cc",
-          "version": "2.0.1"
+          "revision": "e74f0895855b56147cb96f2d45aba3ec37da64fb",
+          "version": "3.0.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
         .package(url: "https://github.com/JohnSundell/Wrap.git", from: "3.0.0"),
         .package(url: "https://github.com/JohnSundell/ShellOut.git", from: "2.0.0"),
         .package(url: "https://github.com/JohnSundell/Require.git", from: "2.0.0"),
-        .package(url: "https://github.com/JohnSundell/Releases.git", from: "2.0.0")
+        .package(url: "https://github.com/JohnSundell/Releases.git", from: "3.0.0")
     ],
     targets: [
         .target(


### PR DESCRIPTION
Resolves the last Swift 4.1 warnings when building the project