### PR TITLE
Update Unbox version to 3.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/JohnSundell/Unbox.git",
         "state": {
           "branch": null,
-          "revision": "17ad6aa1cc2f1efa27a0bbbdb66f79796708aa95",
-          "version": "2.5.0"
+          "revision": "e084f13aea85495b07d015e893845e097a5eaeb4",
+          "version": "3.0.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/JohnSundell/Files.git", from: "2.0.0"),
-        .package(url: "https://github.com/JohnSundell/Unbox.git", from: "2.0.0"),
+        .package(url: "https://github.com/JohnSundell/Unbox.git", from: "3.0.0"),
         .package(url: "https://github.com/JohnSundell/Wrap.git", from: "3.0.0"),
         .package(url: "https://github.com/JohnSundell/ShellOut.git", from: "2.0.0"),
         .package(url: "https://github.com/JohnSundell/Require.git", from: "2.0.0"),


### PR DESCRIPTION
## What
This updates Unbox to 3.0.

## Why
Unbox 3.0 has official Swift 4.1 support.

## How
* Edit entry in Package.swift, run `swift package update`.

## Questions/Concerns
* Several other external dependencies also have new versions, and making a separate PR for each of them might be more trouble than it's worth
    * Please confirm if you prefer separate PRs, or a single one 