### PR TITLE
PackageManager: Support Swift 4.2

### DIFF
--- a/Sources/MarathonCore/PackageManager.swift
+++ b/Sources/MarathonCore/PackageManager.swift
@@ -390,7 +390,11 @@ public final class PackageManager {
             description.append("])],\n")
         }
 
-        description.append("    swiftLanguageVersions: [\(toolsVersion.major)]\n)")
+        if toolsVersion.major >= 4 && toolsVersion.minor >= 2 {
+            description.append("    swiftLanguageVersions: [.version(\"\(toolsVersion.major).\(toolsVersion.minor)\")]\n)")
+        } else {
+            description.append("    swiftLanguageVersions: [\(toolsVersion.major)]\n)")
+        }
 
         try generatedFolder.createFile(named: "Package.swift",
                                        contents: description.data(using: .utf8).require())
@@ -418,7 +422,10 @@ public final class PackageManager {
     }
 
     private func makePackageDescriptionHeader(forSwiftToolsVersion toolsVersion: Version) -> String {
-        let versionString = toolsVersion.string.trimmingCharacters(in: .whitespaces)
-        return "// swift-tools-version:\(versionString)"
+        let swiftVersion = toolsVersion.string.trimmingCharacters(in: .whitespaces)
+        let generationVersion = 1
+
+        return "// swift-tools-version:\(swiftVersion)\n" +
+               "// marathon-generation-version:\(generationVersion)"
     }
 }


### PR DESCRIPTION
Swift 4.2 introduces a new syntax to express Swift language versions in a SwiftPM manifest. To handle that, `PackageManager` now detects the Swift version used to compile a script, and adjusts the syntax accordingly.

Ideally we’d have a more declarative way to model these type of code paths, but that’s a refactor for the future :)

Also, to make these kind of changes able to take effect without requiring users to blast their `~/.marathon` folder, a `marathon-generation-version` header is introduced into generated Package.swift manifests. This version can be bumped in order for Marathon to force-re-generate all Package manifests, in case of syntax changes like this one. This change is backwards compatible.