### PR TITLE
[WIP]: Min deployment target

### DIFF
--- a/Sources/MarathonCore/Install.swift
+++ b/Sources/MarathonCore/Install.swift
@@ -40,12 +40,14 @@ internal class InstallTask: Task, Executable {
 
         let script = try scriptManager.script(atPath: path, allowRemote: true)
         let installPath = makeInstallPath(for: script)
+        
+        let minMacosVersion = script.information.getValue(forKey: .minMacosVersion)
 
         printer.reportProgress("Compiling script...")
         #if os(Linux)
-            try script.build(withMinMacosVersion: script.information.minMacosVersion, withArguments: ["-c", "release"])
+            try script.build(withMinMacosVersion: minMacosVersion, withArguments: ["-c", "release"])
         #else
-            try script.build(withMinMacosVersion: script.information.minMacosVersion, withArguments: ["-c", "release", "-Xswiftc", "-static-stdlib"])
+            try script.build(withMinMacosVersion: minMacosVersion, withArguments: ["-c", "release", "-Xswiftc", "-static-stdlib"])
         #endif
         printer.reportProgress("Installing binary...")
         let installed = try script.install(at: installPath, confirmBeforeOverwriting: !arguments.contains("--force"))

--- a/Sources/MarathonCore/Install.swift
+++ b/Sources/MarathonCore/Install.swift
@@ -43,9 +43,9 @@ internal class InstallTask: Task, Executable {
 
         printer.reportProgress("Compiling script...")
         #if os(Linux)
-            try script.build(withArguments: ["-c", "release"])
+            try script.build(withMinMacosVersion: script.information.minMacosVersion, withArguments: ["-c", "release"])
         #else
-            try script.build(withArguments: ["-c", "release", "-Xswiftc", "-static-stdlib"])
+            try script.build(withMinMacosVersion: script.information.minMacosVersion, withArguments: ["-c", "release", "-Xswiftc", "-static-stdlib"])
         #endif
         printer.reportProgress("Installing binary...")
         let installed = try script.install(at: installPath, confirmBeforeOverwriting: !arguments.contains("--force"))

--- a/Sources/MarathonCore/Install.swift
+++ b/Sources/MarathonCore/Install.swift
@@ -41,13 +41,13 @@ internal class InstallTask: Task, Executable {
         let script = try scriptManager.script(atPath: path, allowRemote: true)
         let installPath = makeInstallPath(for: script)
         
-        let minMacosVersion = script.information.getValue(forKey: .minMacosVersion)
+        let minDeploymentTarget = script.information.getValue(forKey: .minDeploymentTarget)
 
         printer.reportProgress("Compiling script...")
         #if os(Linux)
-            try script.build(withMinMacosVersion: minMacosVersion, withArguments: ["-c", "release"])
+            try script.build(withMinDeploymentTarget: minDeploymentTarget, withArguments: ["-c", "release"])
         #else
-            try script.build(withMinMacosVersion: minMacosVersion, withArguments: ["-c", "release", "-Xswiftc", "-static-stdlib"])
+            try script.build(withMinDeploymentTarget: minDeploymentTarget, withArguments: ["-c", "release", "-Xswiftc", "-static-stdlib"])
         #endif
         printer.reportProgress("Installing binary...")
         let installed = try script.install(at: installPath, confirmBeforeOverwriting: !arguments.contains("--force"))

--- a/Sources/MarathonCore/Run.swift
+++ b/Sources/MarathonCore/Run.swift
@@ -48,8 +48,8 @@ internal class RunTask: Task, Executable {
         }
 
         let script = try scriptManager.script(atPath: path, allowRemote: true)
-        let minMacosVersion = script.information.getValue(forKey: .minMacosVersion)
-        try script.build(withMinMacosVersion: minMacosVersion)
+        let minDeploymentTarget = script.information.getValue(forKey: .minDeploymentTarget)
+        try script.build(withMinDeploymentTarget: minDeploymentTarget)
 
         do {
             let output = try script.run(in: folder, with: Array(arguments.dropFirst()))

--- a/Sources/MarathonCore/Run.swift
+++ b/Sources/MarathonCore/Run.swift
@@ -48,7 +48,8 @@ internal class RunTask: Task, Executable {
         }
 
         let script = try scriptManager.script(atPath: path, allowRemote: true)
-        try script.build(withMinMacosVersion: script.information.minMacosVersion)
+        let minMacosVersion = script.information.getValue(forKey: .minMacosVersion)
+        try script.build(withMinMacosVersion: minMacosVersion)
 
         do {
             let output = try script.run(in: folder, with: Array(arguments.dropFirst()))

--- a/Sources/MarathonCore/Run.swift
+++ b/Sources/MarathonCore/Run.swift
@@ -48,7 +48,7 @@ internal class RunTask: Task, Executable {
         }
 
         let script = try scriptManager.script(atPath: path, allowRemote: true)
-        try script.build()
+        try script.build(withMinMacosVersion: script.information.minMacosVersion)
 
         do {
             let output = try script.run(in: folder, with: Array(arguments.dropFirst()))

--- a/Sources/MarathonCore/Script.swift
+++ b/Sources/MarathonCore/Script.swift
@@ -69,6 +69,7 @@ public final class Script {
 
     public let name: String
     public let folder: Folder
+    public let information: ScriptInformation
 
     private let printer: Printer
     private var copyLoopDispatchQueue: DispatchQueue?
@@ -76,17 +77,19 @@ public final class Script {
 
     // MARK: - Init
 
-    init(name: String, folder: Folder, printer: Printer) {
+    init(name: String, folder: Folder, printer: Printer, information: ScriptInformation) {
         self.name = name
         self.folder = folder
         self.printer = printer
+        self.information = information
     }
 
     // MARK: - API
 
-    public func build(withArguments arguments: [String] = []) throws {
+    public func build(withMinMacosVersion minMacosVersion: String, withArguments arguments: [String] = []) throws {
         do {
-            let command = "build -C \(folder.path) " + arguments.joined(separator: " ")
+            let deploymentTargetArguments = ["-Xswiftc", "-target", "-Xswiftc", "x86_64-apple-macosx\(minMacosVersion)"]
+            let command = "build -C \(folder.path) " + (deploymentTargetArguments + arguments).joined(separator: " ")
             try shellOutToSwiftCommand(command, in: folder, printer: printer)
         } catch {
             throw formatBuildError(error as! ShellOutError)

--- a/Sources/MarathonCore/Script.swift
+++ b/Sources/MarathonCore/Script.swift
@@ -69,7 +69,7 @@ public final class Script {
 
     public let name: String
     public let folder: Folder
-    public let information: ScriptInformation
+    public var information: ScriptInformation
 
     private let printer: Printer
     private var copyLoopDispatchQueue: DispatchQueue?
@@ -171,7 +171,7 @@ public final class Script {
         }
     }
 
-    func resolveMarathonFile(fileName: String) throws -> MarathonFile? {
+    func resolveMarathonFile(fileName: String, separator: String) throws -> MarathonFile? {
         let scriptFile = try File(path: expandSymlink())
 
         guard let parentFolder = scriptFile.parent else {
@@ -182,7 +182,7 @@ public final class Script {
             return nil
         }
 
-        return try MarathonFile(file: file)
+        return try MarathonFile(file: file, separator: separator)
     }
 
     // MARK: - Private

--- a/Sources/MarathonCore/Script.swift
+++ b/Sources/MarathonCore/Script.swift
@@ -86,9 +86,9 @@ public final class Script {
 
     // MARK: - API
 
-    public func build(withMinMacosVersion minMacosVersion: String, withArguments arguments: [String] = []) throws {
+    public func build(withMinDeploymentTarget minDeploymentTarget: String, withArguments arguments: [String] = []) throws {
         do {
-            let deploymentTargetArguments = ["-Xswiftc", "-target", "-Xswiftc", "x86_64-apple-macosx\(minMacosVersion)"]
+            let deploymentTargetArguments = ["-Xswiftc", "-target", "-Xswiftc", minDeploymentTarget]
             let command = "build -C \(folder.path) " + (deploymentTargetArguments + arguments).joined(separator: " ")
             try shellOutToSwiftCommand(command, in: folder, printer: printer)
         } catch {

--- a/Sources/MarathonCore/ScriptInformation.swift
+++ b/Sources/MarathonCore/ScriptInformation.swift
@@ -6,19 +6,68 @@
 
 import Foundation
 
-public struct ScriptInformation {
-    var minMacosVersion: String
+// MARK: - Error
+
+public enum ScriptInformationError {
+    case invalidFormat(String, String)
+    case wrongKey(String, [String])
 }
 
-extension ScriptInformation {
-    static var `default`: ScriptInformation {
-        return ScriptInformation(
-            minMacosVersion: "10.9"
-        )
+extension ScriptInformationError: PrintableError {
+    public var message: String {
+        switch self {
+        case let .invalidFormat(information, _):
+            return "Could not process the inline information: '\(information)'"
+        case let .wrongKey(key, _):
+            return "The key '\(key)' is not valid"
+        }
+    }
+    
+    public var hints: [String] {
+        switch self {
+        case let .invalidFormat(_, separator):
+            return ["Please verify that the inline information provided follows the format <key>\(separator)<value>"]
+        case let .wrongKey(_, availableKeys):
+            return ["The available keys are: \(availableKeys.joined(separator: ", "))"]
+        }
     }
 }
 
-enum ScriptInformationKeys: String {
+public typealias ScriptInformation = [ScriptInformationKey: String]
+
+public extension Dictionary where Key == ScriptInformation.Key, Value == ScriptInformation.Value {
+    private typealias Error = ScriptInformationError
+
+    static func resolve(from line: String, separator: String) throws -> ScriptInformation.Element {
+        let components = line.components(separatedBy: separator)
+        
+        guard components.count == 2 else {
+            throw Error.invalidFormat(line, separator)
+        }
+        
+        let keyString = components[0].trimmingCharacters(in: .whitespaces)
+        guard let informationKey = ScriptInformationKey(rawValue: keyString) else {
+            throw Error.wrongKey(keyString, ["TODO: pass the keys here when updated to swift 4.2"]) // TODO: print all the possible keys for inline information when updated to swift 4.2
+        }
+        
+        let valueString = components[1].trimmingCharacters(in: .whitespaces)
+        switch informationKey {
+        case .minMacosVersion: return (key: .minMacosVersion, value: valueString)
+        }
+    }
+    
+    func getValue(forKey key: Key) -> Value {
+        return self[key] ?? key.defaultValue
+    }
+}
+
+public enum ScriptInformationKey: String {
     case minMacosVersion = "min-macos-version"
+    
+    var defaultValue: String {
+        switch self {
+        case .minMacosVersion: return "10.9"
+        }
+    }
 }
 

--- a/Sources/MarathonCore/ScriptInformation.swift
+++ b/Sources/MarathonCore/ScriptInformation.swift
@@ -10,6 +10,14 @@ public struct ScriptInformation {
     var minMacosVersion: String
 }
 
+extension ScriptInformation {
+    static var `default`: ScriptInformation {
+        return ScriptInformation(
+            minMacosVersion: "10.9"
+        )
+    }
+}
+
 enum ScriptInformationKeys: String {
     case minMacosVersion = "min-macos-version"
 }

--- a/Sources/MarathonCore/ScriptInformation.swift
+++ b/Sources/MarathonCore/ScriptInformation.swift
@@ -1,0 +1,16 @@
+/**
+ *  Marathon
+ *  Copyright (c) John Sundell 2017
+ *  Licensed under the MIT license. See LICENSE file.
+ */
+
+import Foundation
+
+public struct ScriptInformation {
+    var minMacosVersion: String
+}
+
+enum ScriptInformationKeys: String {
+    case minMacosVersion = "min-macos-version"
+}
+

--- a/Sources/MarathonCore/ScriptInformation.swift
+++ b/Sources/MarathonCore/ScriptInformation.swift
@@ -5,6 +5,7 @@
  */
 
 import Foundation
+import ShellOut
 
 // MARK: - Error
 
@@ -52,7 +53,7 @@ public extension Dictionary where Key == ScriptInformation.Key, Value == ScriptI
         
         let valueString = components[1].trimmingCharacters(in: .whitespaces)
         switch informationKey {
-        case .minMacosVersion: return (key: .minMacosVersion, value: valueString)
+        case .minDeploymentTarget: return (key: .minDeploymentTarget, value: valueString)
         }
     }
     
@@ -62,11 +63,17 @@ public extension Dictionary where Key == ScriptInformation.Key, Value == ScriptI
 }
 
 public enum ScriptInformationKey: String {
-    case minMacosVersion = "min-macos-version"
+    case minDeploymentTarget = "min-deployment-target"
     
     var defaultValue: String {
         switch self {
-        case .minMacosVersion: return "10.9"
+        case .minDeploymentTarget:
+            #if os(Linux)
+            return "x86_64-unknown-linux-gnu" // This should be the default target when runnning in linux
+            #else
+            let systemVersion = try? shellOut(to: "sw_vers -productVersion")
+            return "x86_64-apple-macosx" + (systemVersion ?? "10.9")
+            #endif
         }
     }
 }

--- a/Sources/MarathonCore/ScriptManager.swift
+++ b/Sources/MarathonCore/ScriptManager.swift
@@ -366,11 +366,11 @@ public final class ScriptManager {
                 throw Error.invalidInlineInformation(line)
             }
             
-            guard let informationKey = ScriptInformationKeys(rawValue: informationComponents[0]) else {
+            guard let informationKey = ScriptInformationKeys(rawValue: informationComponents[0].trimmingCharacters(in: .whitespaces)) else {
                 throw Error.invalidInlineInformation(line)
             }
             
-            let informationValue = informationComponents[1]
+            let informationValue = informationComponents[1].trimmingCharacters(in: .whitespaces)
             
             switch informationKey {
             case .minMacosVersion: information.minMacosVersion = informationValue

--- a/Sources/MarathonCore/ScriptManager.swift
+++ b/Sources/MarathonCore/ScriptManager.swift
@@ -17,7 +17,7 @@ public enum ScriptManagerError {
     case failedToRemoveScriptFolder(Folder)
     case failedToDownloadScript(URL, Error)
     case invalidInlineDependencyURL(String)
-    case invalidInlineInformation(String)
+    case invalidInlineInformationFormat(String)
     case noSwiftFilesInRepository(URL)
     case multipleSwiftFilesInRepository(URL, [File])
     case remoteScriptNotAllowed
@@ -38,7 +38,7 @@ extension ScriptManagerError: PrintableError {
             return "Failed to download script from '\(url.absoluteString)' (\(error))"
         case .invalidInlineDependencyURL(let urlString):
             return "Could not resolve inline dependency '\(urlString)'"
-        case .invalidInlineInformation(let information): // TODO: print all the possible keys for inline information when updated to swift 4.2
+        case .invalidInlineInformationFormat(let information):
             return "Could not resolve inline information: '\(information)'"
         case .noSwiftFilesInRepository(let url):
             return "No Swift files found in repository at '\(url.absoluteString)'"
@@ -62,8 +62,8 @@ extension ScriptManagerError: PrintableError {
             return ["Make sure that the URL is reachable, and that it contains a valid Swift script"]
         case .invalidInlineDependencyURL, .noSwiftFilesInRepository:
             return ["Please verify that the URL is correct and try again"]
-        case .invalidInlineInformation:
-            return ["Please verify that the inline information provided is valid and supported (double check the spelling!)"]
+        case .invalidInlineInformationFormat:
+            return ["Please verify that the inline information provided is valid and supported"]
         case .multipleSwiftFilesInRepository(_, let files):
             let fileNames = files.map({ $0.name }).joined(separator: "\n- ")
             return ["Please run one of the following scripts using its direct URL instead:\n- \(fileNames)"]
@@ -360,7 +360,7 @@ public final class ScriptManager {
             let components = line.components(separatedBy: config.prefix)
             
             guard components.count == 2 else {
-                throw Error.invalidInlineInformation(line)
+                throw Error.invalidInlineInformationFormat(line)
             }
             
             let element = try ScriptInformation.resolve(from: components[1], separator: config.separator)

--- a/Sources/MarathonCore/ScriptManager.swift
+++ b/Sources/MarathonCore/ScriptManager.swift
@@ -351,7 +351,7 @@ public final class ScriptManager {
     
     private func resolveScriptInformation(from file: File) throws -> ScriptInformation {
         let lines = try file.readAsString().components(separatedBy: .newlines)
-        var information = ScriptInformation(minMacosVersion: "10.11")
+        var information = ScriptInformation.default
         
         for line in lines where line.hasPrefix("//") && line.contains(config.prefix) {
             let components = line.components(separatedBy: config.prefix)


### PR DESCRIPTION
Implementation for passing the minimum deployment target in an inline comment from inside the script, and also adding it in the marathonFile. In addition, when running in macos, the minimum deployment target is obtained from the machine where Marathon is executed.

This is WIP. Can I get some initial feedback on this? Thanks!

TODO:
- Add tests

Example:
- Inline, inside the script, you can specify:
`// marathon:min-deployment-target:x86_64-apple-macosx10.13`

- In the MarathonFile you can specify:
`min-deployment-target:x86_64-apple-macosx10.13`

- Also, if running in macos you do not need to specify anything: the system version will be used as minimum deployment target.

MarathonFile configuration has priority over the one specified inside the script