### PR TITLE
[WIP]: Multi dependency package support & other proposed fixes/improvements

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.1
+// swift-tools-version:4.2
 
 /**
  *  Marathon

--- a/Sources/MarathonCore/Dependency.swift
+++ b/Sources/MarathonCore/Dependency.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+public struct Dependency {
+    public let name: String?
+    public let url: URL
+}
+
+extension Dependency: Equatable {
+    public static func ==(lhs: Dependency, rhs: Dependency) -> Bool {
+        return
+            lhs.name == rhs.name
+            && lhs.url == rhs.url
+    }
+}

--- a/Sources/MarathonCore/Dependency.swift
+++ b/Sources/MarathonCore/Dependency.swift
@@ -2,7 +2,7 @@ import Foundation
 
 public struct Dependency {
     public let name: String?
-    public let url: URL
+    public var url: URL
 }
 
 extension Dependency: Equatable {

--- a/Sources/MarathonCore/Package.swift
+++ b/Sources/MarathonCore/Package.swift
@@ -58,6 +58,10 @@ internal extension Package {
         if toolsVersion.major == 3 {
             return ".Package(url: \"\(url.absoluteString)\", majorVersion: \(majorVersion))"
         }
+        
+        if toolsVersion >= Version(major: 4, minor: 2) && !url.isForRemoteRepository {
+            return ".package(path: \"\(url.absoluteString)\")"
+        }
 
         return ".package(url: \"\(url.absoluteString)\", from: \"\(version.major).\(version.minor).\(version.patch)\")"
     }

--- a/Sources/MarathonCore/Package.swift
+++ b/Sources/MarathonCore/Package.swift
@@ -11,12 +11,19 @@ import Releases
 public struct Package {
     public let name: String
     public let url: URL
-    public var majorVersion: Int
+    public var version: Version
+    public var majorVersion: Int { return version.major }
 }
 
 extension Package: Equatable {
     public static func ==(lhs: Package, rhs: Package) -> Bool {
-        return lhs.url == rhs.url && lhs.majorVersion == rhs.majorVersion
+        return lhs.url == rhs.url && lhs.version == rhs.version
+    }
+}
+
+extension Package: Hashable {
+    public var hashValue: Int {
+        return "\(url.absoluteString);\(version.description)".hashValue
     }
 }
 
@@ -24,7 +31,17 @@ extension Package: Unboxable {
     public init(unboxer: Unboxer) throws {
         name = try unboxer.unbox(key: "name")
         url = try unboxer.unbox(key: "url")
-        majorVersion = try unboxer.unbox(key: "majorVersion")
+        
+        if let versionData: [String: Int] = try? unboxer.unbox(key: "version")
+            , let major: Int = versionData["major"]
+            , let minor: Int = versionData["minor"]
+            , let patch: Int = versionData["patch"] {
+            version = Version(major: major, minor: minor, patch: patch, prefix: nil, suffix: nil)
+        } else {
+            let majorVersion: Int = try unboxer.unbox(key: "majorVersion")
+            version = Version(major: majorVersion)
+        }
+        
     }
 }
 
@@ -42,7 +59,7 @@ internal extension Package {
             return ".Package(url: \"\(url.absoluteString)\", majorVersion: \(majorVersion))"
         }
 
-        return ".package(url: \"\(url.absoluteString)\", from: \"\(majorVersion).0.0\")"
+        return ".package(url: \"\(url.absoluteString)\", from: \"\(version.major).\(version.minor).\(version.patch)\")"
     }
 }
 

--- a/Sources/MarathonCore/PackageManager.swift
+++ b/Sources/MarathonCore/PackageManager.swift
@@ -124,18 +124,21 @@ public final class PackageManager {
         return package
     }
 
-    public func addPackagesIfNeeded(from dependencies: [Dependency]) throws {
+    public func addPackagesIfNeeded(from dependencies: [Dependency]) throws -> [Dependency] {
         let existingPackages = makePackageList()
 
-        for dependency in dependencies {
-            let exists = try existingPackages.contains { (package) throws -> Bool in
+        return try dependencies.map { dependency throws in
+            let existingPackage = try existingPackages.first { (package) throws -> Bool in
                 return package.url.absoluteString.lowercased() == dependency.url.absoluteString.lowercased()
             }
-            guard !exists else {
-                continue
+            guard existingPackage == nil else {
+                return dependency
             }
 
-            try addPackage(at: dependency.url, throwIfAlreadyAdded: false)
+            let newPackage = try addPackage(at: dependency.url, throwIfAlreadyAdded: false)
+            var dep = dependency
+            dep.url = newPackage.url // make sure that any ~ or trailing slashes are identical by setting a new URL on the dependency
+            return dep
         }
     }
 

--- a/Sources/MarathonCore/PackageManager.swift
+++ b/Sources/MarathonCore/PackageManager.swift
@@ -169,18 +169,8 @@ public final class PackageManager {
     }
 
     public func makePackageDescription(for script: Script) throws -> String {
-        guard let masterDescription = try? generatedFolder.file(named: "Package.swift").readAsString() else {
-            try updatePackages()
-            return try makePackageDescription(for: script)
-        }
-
         let toolsVersion = try resolveSwiftToolsVersion()
         let expectedHeader = makePackageDescriptionHeader(forSwiftToolsVersion: toolsVersion)
-
-        guard masterDescription.hasPrefix(expectedHeader) else {
-            try generateMasterPackageDescription(forSwiftToolsVersion: toolsVersion)
-            return try makePackageDescription(for: script)
-        }
 
         return try generatePackageDescription(for: script, toolsVersion: toolsVersion)
     }
@@ -319,14 +309,14 @@ public final class PackageManager {
     private func updatePackages() throws {
         printer.reportProgress("Updating packages...")
 
-        do {
-            let toolsVersion = try resolveSwiftToolsVersion()
-            try generateMasterPackageDescription(forSwiftToolsVersion: toolsVersion)
-            try shellOutToSwiftCommand("package update", in: generatedFolder, printer: printer)
-            try generatedFolder.createSubfolderIfNeeded(withName: "Packages")
-        } catch {
-            throw Error.failedToUpdatePackages(folder)
-        }
+//        do {
+//            let toolsVersion = try resolveSwiftToolsVersion()
+//            try generateMasterPackageDescription(forSwiftToolsVersion: toolsVersion)
+//            try shellOutToSwiftCommand("package update", in: generatedFolder, printer: printer)
+//            try generatedFolder.createSubfolderIfNeeded(withName: "Packages")
+//        } catch {
+//            throw Error.failedToUpdatePackages(folder)
+//        }
     }
 
     private func addMissingPackageFiles() {

--- a/Sources/MarathonCore/Script.swift
+++ b/Sources/MarathonCore/Script.swift
@@ -69,6 +69,7 @@ public final class Script {
 
     public let name: String
     public let folder: Folder
+    public var dependencies: [Dependency]
 
     private let printer: Printer
     private var copyLoopDispatchQueue: DispatchQueue?
@@ -76,9 +77,10 @@ public final class Script {
 
     // MARK: - Init
 
-    init(name: String, folder: Folder, printer: Printer) {
+    init(name: String, folder: Folder, dependencies: [Dependency], printer: Printer) {
         self.name = name
         self.folder = folder
+        self.dependencies = dependencies
         self.printer = printer
     }
 

--- a/Sources/MarathonCore/ScriptManager.swift
+++ b/Sources/MarathonCore/ScriptManager.swift
@@ -280,7 +280,7 @@ public final class ScriptManager {
 
     private func createFolderIfNeededForScript(withIdentifier identifier: String, file: File) throws -> Folder {
         let scriptFolder = try cacheFolder.createSubfolderIfNeeded(withName: identifier)
-        try packageManager.symlinkPackages(to: scriptFolder)
+//        try packageManager.symlinkPackages(to: scriptFolder)
 
         if (try? scriptFolder.file(named: "OriginalFile")) == nil {
             try scriptFolder.createSymlink(to: file.path, at: "OriginalFile", printer: printer)

--- a/Sources/MarathonCore/ScriptManager.swift
+++ b/Sources/MarathonCore/ScriptManager.swift
@@ -173,9 +173,9 @@ public final class ScriptManager {
         
         if let marathonFile = try script.resolveMarathonFile(fileName: config.dependencyFile) {
             let marathonFileDependencies: [Dependency] = marathonFile.packageURLs.map { Dependency(name: nil, url: $0) }
-            try packageManager.addPackagesIfNeeded(from: marathonFileDependencies)
+            let resolvedDependencies = try packageManager.addPackagesIfNeeded(from: marathonFileDependencies)
             try addDependencyScripts(fromMarathonFile: marathonFile, for: script)
-            script.dependencies += marathonFileDependencies
+            script.dependencies += resolvedDependencies
         }
 
         script.dependencies += try resolveInlineDependencies(from: file)
@@ -343,8 +343,7 @@ public final class ScriptManager {
             }
         }
 
-        try packageManager.addPackagesIfNeeded(from: dependencies)
-        return dependencies
+        return try packageManager.addPackagesIfNeeded(from: dependencies)
     }
 
     private func makeManagedScriptPathList() -> [String] {


### PR DESCRIPTION
This PR is a WIP of fixes for issues in #189, #191 as well as some other things I'll mention in notes below.

The changes are primarily trying to address importing dependencies from a package that may not go by the same name as the package, or situations where there are multiple libraries from a package that you are trying to import. Along the way, I noticed some issues with the Master Package Description and the way it acts as a template for the `Package.swift` files used in every script. As a result, in this current WIP code, the Master `Package.swift` is mostly unused and package update functionality is currently disabled. 

I was mostly working with MarathonCore directly, not via CLI, but problems with the Master Package Description pattern I saw were:
- After running Marathon a few times the dependencies of dependencies start getting added to the Master `Package.swift`, which are then copied over into the script `Package.swift` files.
- This also means that if you have many scripts with dependencies then copying from the Master `Package.swift` will make the scripts depend on each other's libraries
- Updating all packages to run some scripts that may not even have many dependencies can make simple script executions take longer
- I found the versions depended upon in the `Package.swift` files weren't consistent enough because they only used the major version. It could cause issues during `swift package update` as it tried to resolve the dependencies correctly

Notes:
- a new `Dependency` struct has been introduced that maintains the name of the specific library you want to include, not just the name of the package.
- if swift tools version is 4.2 or greater then local references use the `.package(path:"")` format

This work is currently incomplete but I wanted to open a PR with my first shot at the problem as a proposal. Since it's a big change and there is lots of room for discussion.

Thanks for reading/reviewing!