### PR TITLE
Integrate ImportSpecification to support swift-sh style of imports

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -11,6 +11,15 @@
         }
       },
       {
+        "package": "ImportSpecification",
+        "repositoryURL": "https://github.com/alexito4/ImportSpecification",
+        "state": {
+          "branch": null,
+          "revision": "c80c1b52fcc47ebd3d86354603d0d81b9faae27f",
+          "version": "0.4.0"
+        }
+      },
+      {
         "package": "Releases",
         "repositoryURL": "https://github.com/JohnSundell/Releases.git",
         "state": {

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,8 @@ let package = Package(
         .package(url: "https://github.com/JohnSundell/Wrap.git", from: "3.0.0"),
         .package(url: "https://github.com/JohnSundell/ShellOut.git", from: "2.0.0"),
         .package(url: "https://github.com/JohnSundell/Require.git", from: "2.0.0"),
-        .package(url: "https://github.com/JohnSundell/Releases.git", from: "3.0.0")
+        .package(url: "https://github.com/JohnSundell/Releases.git", from: "3.0.0"),
+        .package(url: "https://github.com/alexito4/ImportSpecification", from: "0.4.0")
     ],
     targets: [
         .target(
@@ -29,7 +30,7 @@ let package = Package(
         ),
         .target(
             name: "MarathonCore",
-            dependencies: ["Files", "Unbox", "Wrap", "ShellOut", "Require", "Releases"]
+            dependencies: ["Files", "Unbox", "Wrap", "ShellOut", "Require", "Releases", "ImportSpecification"]
         ),
         .testTarget(
             name: "MarathonTests",

--- a/Tests/MarathonTests/MarathonTests.swift
+++ b/Tests/MarathonTests/MarathonTests.swift
@@ -245,6 +245,16 @@ class MarathonTests: XCTestCase {
         try scriptFile.write(string: script)
         try run(with: ["run", scriptFile.path])
     }
+    
+    func testRunningScriptWithImportSpecification() throws {
+        let script = """
+        import Files // JohnSundell/Files ~> 2.2
+        print(Folder.current.path)
+        """
+        let scriptFile = try folder.createFile(named: "script.swift")
+        try scriptFile.write(string: script)
+        try run(with: ["run", scriptFile.path])
+    }
 
     func testRunningScriptWithBuildFailedErrorThrows() throws {
         let scriptFile = try folder.createFile(named: "script.swift")
@@ -837,6 +847,7 @@ extension MarathonTests {
             ("testRunningScriptWithoutPathThrows", testRunningScriptWithoutPathThrows),
             ("testRunningScript", testRunningScript),
             ("testRunningScriptWithNewDependency", testRunningScriptWithNewDependency),
+            ("testRunningScriptWithImportSpecification", testRunningScriptWithImportSpecification),
             ("testRunningScriptWithBuildFailedErrorThrows", testRunningScriptWithBuildFailedErrorThrows),
             ("testRunningScriptWithBuildFailedErrorWhenNoSuchModuleThrows", testRunningScriptWithBuildFailedErrorWhenNoSuchModuleThrows),
             ("testRunningScriptWithRuntimeErrorThrows", testRunningScriptWithRuntimeErrorThrows),


### PR DESCRIPTION
Hi!
I've been working on improving the compatibility of different Swift scripting tools. I wanted to be able to use [swift-sh](https://github.com/mxcl/swift-sh) and Marathon with the same script without having to change anything, including the import statements. 

The style of the comment that Marathon uses is different than the one that swift-sh uses:

```
import Files // marathon:https://github.com/JohnSundell/Files.git
```

vs.

```
import Files // JohnSundell/Files ~> 2.2
```

I've factored out the parsing logic from swift-sh and created a separate package for it  [alexito4/ImportSpecification](https://github.com/alexito4/ImportSpecification) so different tools can use the same syntax. 

This PR integrates this package with Marathon while keeping the current syntax available, so it's not a breaking change. The changes are quite minimal, and ImportSpecification itself is quite small, taken directly from swift-sh code. 

Let me know what you think, I have a [PR against swift-sh](https://github.com/mxcl/swift-sh/pull/44) also. I've given it a try ant is really nice to be able to work with swift-sh, but then use all the power of Marathon to edit with Xcode or create binaries. 

Thanks for considering it.