### PR TITLE
Support Swift 5 scripting

### DIFF
--- a/Sources/MarathonCore/PackageManager.swift
+++ b/Sources/MarathonCore/PackageManager.swift
@@ -391,8 +391,14 @@ public final class PackageManager {
             description.append("])],\n")
         }
 
-        if toolsVersion.major >= 4 && toolsVersion.minor >= 2 {
-            description.append("    swiftLanguageVersions: [.version(\"\(toolsVersion.major).\(toolsVersion.minor)\")]\n)")
+        if toolsVersion >= Version(major: 4, minor: 2) {
+            var versionString = String(toolsVersion.major)
+
+            if toolsVersion.minor > 0 {
+                versionString.append(".\(toolsVersion.minor)")
+            }
+
+            description.append("    swiftLanguageVersions: [.version(\"\(versionString)\")]\n)")
         } else {
             description.append("    swiftLanguageVersions: [\(toolsVersion.major)]\n)")
         }

--- a/Tests/MarathonTests/MarathonTests.swift
+++ b/Tests/MarathonTests/MarathonTests.swift
@@ -45,7 +45,7 @@ class MarathonTests: XCTestCase {
 
         let packagesFolder = try generatedFolder.subfolder(named: ".build/checkouts")
         XCTAssertEqual(packagesFolder.subfolders.count, 1)
-        XCTAssertEqual(packagesFolder.subfolders.first?.name.hasPrefix("Files.git"), true)
+        XCTAssertEqual(packagesFolder.subfolders.first?.name.hasPrefix("Files"), true)
 
         // List should now include the package
         try XCTAssertTrue(run(with: ["list"]).contains("https://github.com/JohnSundell/Files.git"))
@@ -76,7 +76,7 @@ class MarathonTests: XCTestCase {
 
         let packagesFolder = try generatedFolder.subfolder(atPath: ".build/checkouts")
         XCTAssertEqual(packagesFolder.subfolders.count, 1)
-        XCTAssertEqual(packagesFolder.subfolders.first?.name.hasPrefix("TestPackage-"), true)
+        XCTAssertEqual(packagesFolder.subfolders.first?.name.hasPrefix("TestPackage"), true)
 
         // List should now include the package
         try XCTAssertTrue(run(with: ["list"]).contains(packageFolder.path))
@@ -110,8 +110,11 @@ class MarathonTests: XCTestCase {
         let packageFolder = try folder.createSubfolder(named: "TestPackage")
         try packageFolder.moveToAndPerform(command: "swift package init")
 
-        let packageDescription = "import PackageDescription\n" +
-                                 "let package = Package(name: \"TestPackage\")"
+        let packageDescription = """
+        // swift-tools-version:4.2
+        import PackageDescription
+        let package = Package(name: "TestPackage")
+        """
 
         let packageFile = try packageFolder.file(named: "Package.swift")
         try packageFile.write(string: packageDescription)
@@ -129,16 +132,23 @@ class MarathonTests: XCTestCase {
 
         let packageNames = try generatedFolder.subfolder(atPath: ".build/checkouts").subfolders.names
         XCTAssertEqual(packageNames.count, 1)
-        XCTAssertTrue(packageNames.contains { $0.hasPrefix("TestPackage-") })
+        XCTAssertTrue(packageNames.contains { $0.hasPrefix("TestPackage") })
     }
 
     func testAddingLocalPackageWithDependency() throws {
         let packageFolder = try folder.createSubfolder(named: "TestPackage")
         try packageFolder.moveToAndPerform(command: "swift package init")
 
-        let packageDescription = "import PackageDescription\n" +
-                                 "let package = Package(name: \"TestPackage\",\n" +
-                                 "dependencies: [.Package(url: \"https://github.com/johnsundell/Files.git\", majorVersion: 1)])"
+        let packageDescription = """
+        // swift-tools-version:4.2
+        import PackageDescription
+        let package = Package(
+            name: "TestPackage",
+            dependencies: [
+                .package(url: "https://github.com/johnsundell/Files.git", from: "2.0.0")
+            ]
+        )
+        """
 
         let packageFile = try packageFolder.file(named: "Package.swift")
         try packageFile.write(string: packageDescription)
@@ -156,8 +166,8 @@ class MarathonTests: XCTestCase {
 
         let packageNames = try generatedFolder.subfolder(atPath: ".build/checkouts").subfolders.names
         XCTAssertEqual(packageNames.count, 2)
-        XCTAssertTrue(packageNames.contains { $0.hasPrefix("TestPackage-") })
-        XCTAssertTrue(packageNames.contains { $0.hasPrefix("Files.git-") })
+        XCTAssertTrue(packageNames.contains { $0.hasPrefix("TestPackage") })
+        XCTAssertTrue(packageNames.contains { $0.hasPrefix("Files") })
     }
 
     func testAddingLocalPackageWithUnsortedVersionsContainingLetters() throws {
@@ -560,21 +570,21 @@ class MarathonTests: XCTestCase {
         XCTAssertNotNil(checkedOutFolder)
 
         XCTAssertEqual(packagesFolder.subfolders.count, 1)
-        XCTAssertEqual(checkedOutFolder?.name.hasPrefix("TestPackage-"), true)
+        XCTAssertEqual(checkedOutFolder?.name.hasPrefix("TestPackage"), true)
         XCTAssertEqual(try checkedOutFolder?.moveToAndPerform(command: "git tag").contains("0.1.0"), true)
 
         // Bump to a new minor version and update
         try packageFolder.moveToAndPerform(command: "git tag 0.2.0")
         try run(with: ["update"])
         XCTAssertEqual(packagesFolder.subfolders.count, 1)
-        XCTAssertEqual(checkedOutFolder?.name.hasPrefix("TestPackage-"), true)
+        XCTAssertEqual(checkedOutFolder?.name.hasPrefix("TestPackage"), true)
         XCTAssertEqual(try checkedOutFolder?.moveToAndPerform(command: "git tag").contains("0.2.0"), true)
 
         // Bump to a new major version and update
         try packageFolder.moveToAndPerform(command: "git tag 1.0.0")
         try run(with: ["update"])
         XCTAssertEqual(packagesFolder.subfolders.count, 1)
-        XCTAssertEqual(checkedOutFolder?.name.hasPrefix("TestPackage-"), true)
+        XCTAssertEqual(checkedOutFolder?.name.hasPrefix("TestPackage"), true)
         XCTAssertEqual(try checkedOutFolder?.moveToAndPerform(command: "git tag").contains("1.0.0"), true)
     }
 


### PR DESCRIPTION
This change makes it possible to use Marathon with Swift 5 and the latest Xcode beta. The only change required to Marathon itself was to correct the code that compared Swift versions (which currently was hard-wired to compare against `4.2`).

The other changes required were all in the tests, which were making assumptions about Swift Package Manager output that no longer are true.

This is a 100% backward compatible change.